### PR TITLE
Add night mode (dark-hours capture, one video spanning midnight)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Night mode** (`capture.daylight_window.mode: night`): capture only the dark
+  hours (the inverse of the daylight window). A night spans midnight and is
+  saved as one continuous video — frames bucket by a noon-to-noon day — and the
+  capture service builds each night automatically ~5 minutes after its window
+  closes at dawn (the fixed nightly timer can't, since a night finishes in the
+  morning).
 - Timezone-accurate capture: set `capture.timezone` (an IANA name like
   `America/Chicago`) or let it auto-detect from `events.zip` /
   latitude-longitude via Open-Meteo (cached to `data/timezone.txt`). Capture

--- a/README.md
+++ b/README.md
@@ -606,6 +606,25 @@ a live readout of which one is currently active. For a camera left on
 nothing about the moment-to-moment state, so it can't drive a per-frame
 decision. The sunrise/sunset approach above doesn't have that problem.
 
+### Night-only timelapses (night mode)
+
+Set `capture.daylight_window.mode: night` (with the window `enabled`) to do the
+**opposite** of daylight capture — record only the **dark hours** and skip the
+day. It reuses the same sunrise/sunset math, just inverted; `buffer_minutes`
+trims that much twilight off each end of the night instead of extending it.
+
+Because a night spans midnight, night mode buckets frames by a **noon-to-noon
+day**, so one evening plus the following morning become **one continuous video**
+(labeled by the night's start date) instead of two half-clips split at midnight.
+And since a night isn't finished until dawn, the nightly timer can't build it —
+the **capture service builds each night automatically ~5 minutes after its
+window closes at sunrise**. (A manual build still works:
+`build_timelapse.py daily --date YYYY-MM-DD`.)
+
+Night mode needs a location set (`events.zip` or `latitude`/`longitude`), same
+as the daylight window. Leave `yearly.video_window` empty when using it — a
+daylight-hours filter makes no sense for night frames.
+
 ## Security
 
 - **There is no authentication.** The web UI has no login, no access control,

--- a/build_timelapse.py
+++ b/build_timelapse.py
@@ -201,6 +201,16 @@ def season_metadata(cfg, date):
 def cmd_daily(cfg, args):
     start = time.time()
     tz = build_timezone(cfg)
+    dl = cfg["capture"].get("daylight_window") or {}
+    night = bool(dl.get("enabled")) and (dl.get("mode") or "day").strip().lower() == "night"
+    if night and args.date is None:
+        # In night mode the capture service triggers each night's build once the
+        # dawn window closes (a night isn't complete at the fixed nightly-timer
+        # time), so the scheduled/default build is a no-op. An explicit --date
+        # (what the capture service passes) still builds.
+        log.info("night mode: daily builds run when each night ends (capture "
+                 "service). Skipping default build — pass --date to force one.")
+        return
     date = resolve_date(args.date, tz)
     season = season_metadata(cfg, date)
     for cam in selected_cameras(cfg, args.camera):
@@ -518,8 +528,9 @@ def main():
 
     p_daily = sub.add_parser("daily", parents=[shared],
                              help="build a daily video and archive yearly frames")
-    p_daily.add_argument("--date", default="yesterday",
-                         help="YYYY-MM-DD, 'today', or 'yesterday' (default)")
+    p_daily.add_argument("--date", default=None,
+                         help="YYYY-MM-DD, 'today', or 'yesterday' (default). In night "
+                              "mode the default is a no-op — builds are triggered by capture")
     p_daily.add_argument("--camera", default=None, help="only this camera")
 
     p_yearly = sub.add_parser("yearly", parents=[shared],

--- a/capture.py
+++ b/capture.py
@@ -13,6 +13,8 @@ import datetime as dt
 import json
 import logging
 import shutil
+import subprocess
+import sys
 import time
 import uuid
 
@@ -20,8 +22,17 @@ import requests
 import urllib3
 
 import events
-from common import (APP_VERSION, load_config, local_now, local_today,
+from common import (APP_ROOT, APP_VERSION, load_config, local_now, local_today,
                     snapshots_dir, tzinfo_for, videos_dir)
+
+# A "night" spans midnight, so night frames are bucketed by a noon-to-noon
+# logical day (shift the timestamp back 12h). That makes one evening + the
+# following morning land in a single folder — one continuous video — and sort
+# in chronological order by filename.
+NIGHT_DAY_SHIFT = dt.timedelta(hours=12)
+# After a night's capture window closes in the morning, wait this long before
+# kicking off its build, so the last frames are settled.
+NIGHT_BUILD_DELAY = dt.timedelta(minutes=5)
 
 log = logging.getLogger("capture")
 
@@ -91,6 +102,9 @@ class DaylightWindow:
     def __init__(self, cfg, tz=None):
         self.cfg = cfg["capture"].get("daylight_window") or {}
         self.enabled = bool(self.cfg.get("enabled"))
+        # "day" captures inside the sunrise/sunset window; "night" captures its
+        # complement (the dark hours), which spans midnight.
+        self.mode = (self.cfg.get("mode") or "day").strip().lower()
         self.events_cfg = cfg.get("events") or {}
         self.ephem_dir = cfg["storage"]["root"] / "ephemeris"
         self.tz = tz
@@ -212,9 +226,14 @@ def parse_hhmm(value):
 def within_window(now, capture_cfg, daylight=None) -> bool:
     if daylight and daylight.enabled:
         start, end = daylight.window_for(now.date())
-    else:
-        start = parse_hhmm(capture_cfg.get("start_time"))
-        end = parse_hhmm(capture_cfg.get("end_time"))
+        if start is None and end is None:
+            return True  # sunrise/sunset unavailable -> fail open (capture)
+        in_daylight = not ((start and now.time() < start) or (end and now.time() > end))
+        # Night mode captures the complement of the daylight window.
+        return (not in_daylight) if daylight.mode == "night" else in_daylight
+
+    start = parse_hhmm(capture_cfg.get("start_time"))
+    end = parse_hhmm(capture_cfg.get("end_time"))
     if start and now.time() < start:
         return False
     if end and now.time() > end:
@@ -259,6 +278,11 @@ def run_once(cfg, conditions=None, daylight=None, tz=None):
         log.debug("outside capture window, skipping")
         return
 
+    # In night mode, bucket by the noon-to-noon logical day so a night's
+    # evening + following-morning frames share one folder and sort in order.
+    night = bool(daylight and daylight.enabled and daylight.mode == "night")
+    capture_dt = (now - NIGHT_DAY_SHIFT) if night else now
+
     tags = sorted(conditions.tags) if conditions else []
     out_root = snapshots_dir(cfg)
     for cam in cfg["cameras"]:
@@ -269,7 +293,7 @@ def run_once(cfg, conditions=None, daylight=None, tz=None):
             log.info("%s: not at home position, quarantining frame", cam["name"])
         for attempt in (1, 2):
             try:
-                path, size = take_snapshot(cam, capture_cfg, out_root, now, quarantine, tags)
+                path, size = take_snapshot(cam, capture_cfg, out_root, capture_dt, quarantine, tags)
                 log.info("%s: saved %s (%d KB)", cam["name"], path.name, size // 1024)
                 break
             except Exception as exc:
@@ -282,7 +306,22 @@ def run_once(cfg, conditions=None, daylight=None, tz=None):
                     log.error("%s: snapshot failed: %s", cam["name"], msg)
 
 
-def loop(cfg):
+def trigger_night_build(config_path, date):
+    """Launch the daily build for a just-completed night as a detached process,
+    so a slow ffmpeg run never stalls capture. build_timelapse handles its own
+    logging and failures; a bad build must not take capture down."""
+    cmd = [sys.executable, str(APP_ROOT / "build_timelapse.py"),
+           "daily", "--date", date.isoformat()]
+    if config_path:
+        cmd += ["--config", str(config_path)]
+    log.info("night ended — launching build for %s", date)
+    try:
+        subprocess.Popen(cmd)
+    except Exception:
+        log.exception("failed to launch night build for %s", date)
+
+
+def loop(cfg, config_path=None):
     configured_interval = cfg["capture"]["interval_seconds"]
     base_interval = max(MIN_INTERVAL_SECONDS, configured_interval)
     if configured_interval < MIN_INTERVAL_SECONDS:
@@ -293,9 +332,16 @@ def loop(cfg):
     log.info("capture timezone: %s", tz.key if tz is not None else "host system default")
     conditions = Conditions(cfg)
     daylight = DaylightWindow(cfg, tz)
+    night_mode = daylight.enabled and daylight.mode == "night"
     if daylight.enabled and (cfg["capture"].get("start_time") or cfg["capture"].get("end_time")):
         log.warning("capture.daylight_window is enabled; static start_time/end_time are ignored")
+    if night_mode:
+        log.info("night mode: capturing dark hours; each night's video is built "
+                 "~%d min after the window closes at dawn", NIGHT_BUILD_DELAY.seconds // 60)
     last_prune_day = None
+    was_in_window = None
+    pending_build_date = None
+    pending_build_at = None
     while True:
         conditions.refresh()
         # Burst tags (storm/snow) shorten the interval; pick a burst interval
@@ -304,6 +350,21 @@ def loop(cfg):
         now = time.time()
         time.sleep(interval - (now % interval))
         run_once(cfg, conditions, daylight, tz)
+
+        now_local = local_now(tz)
+        if night_mode:
+            # When capture crosses from the night window into daylight at dawn,
+            # the night just finished — schedule its build a few minutes later.
+            in_window = within_window(now_local, cfg["capture"], daylight)
+            if was_in_window and not in_window:
+                pending_build_date = (now_local - NIGHT_DAY_SHIFT).date()
+                pending_build_at = now_local + NIGHT_BUILD_DELAY
+                log.info("night window closed; build for %s scheduled ~%s",
+                         pending_build_date, pending_build_at.strftime("%H:%M"))
+            if pending_build_date and now_local >= pending_build_at:
+                trigger_night_build(config_path, pending_build_date)
+                pending_build_date = pending_build_at = None
+            was_in_window = in_window
 
         today = local_today(tz)
         if today != last_prune_day:
@@ -326,7 +387,7 @@ def main():
     cfg = load_config(args.config)
 
     if args.loop:
-        loop(cfg)
+        loop(cfg, args.config)
     else:
         tz = tzinfo_for(events.resolve_timezone(cfg))
         conditions = Conditions(cfg)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,10 +71,18 @@ capture:
                               # clock window — see the README section on IR
                               # and 24-hour timelapses for why this matters.
     enabled: false            # overrides start_time/end_time when true
-    buffer_minutes: 0         # start this many minutes before sunrise, stop
-                              # this many after sunset. Uses the same location
-                              # as events.zip/latitude/longitude below,
-                              # independent of weather_enabled/lunar_enabled.
+    mode: day                 # "day" captures the daylight window; "night"
+                              # captures its complement (dark hours). A night
+                              # spans midnight and is stored as ONE video (its
+                              # frames bucket by a noon-to-noon day). In night
+                              # mode the capture service builds each night ~5
+                              # min after the dawn window closes, not on the
+                              # nightly timer.
+    buffer_minutes: 0         # day mode: start this many minutes before sunrise,
+                              # stop this many after sunset. Night mode: the
+                              # inverse — trims that many minutes of twilight off
+                              # each end of the night. Uses the same location as
+                              # events.zip/latitude/longitude below.
 
 storage:
   root: ./data                # relative paths resolve next to config.yaml

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -182,6 +182,10 @@ def validate_config(cfg):
     if pw_hash is not None and not isinstance(pw_hash, str):
         problems.append("webapp.config_passcode_hash must be a string (set it via the Config page, not by hand)")
 
+    dl_mode = ((cfg.get("capture") or {}).get("daylight_window") or {}).get("mode")
+    if dl_mode is not None and str(dl_mode).strip().lower() not in ("day", "night"):
+        problems.append('capture.daylight_window.mode must be "day" or "night"')
+
     tzname = (cfg.get("capture") or {}).get("timezone")
     if tzname and tzinfo_for(tzname) is None:
         problems.append(f"capture.timezone {tzname!r} is not a valid IANA time zone "

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -1381,9 +1381,16 @@ function buildCaptureSection() {
     + "this keeps those frames out of the timelapse. Overrides Start/End time below when on; needs a location "
     + "(ZIP or lat/lon) set in Weather & astronomy tagging.",
     checkboxField("capture.daylight_window.enabled", {default: false})));
+  sec.appendChild(fieldRow("Window mode",
+    "With Auto daylight window on: \"day\" captures during daylight (the default); \"night\" captures the "
+    + "opposite — the dark hours only. A night spans midnight and is saved as one continuous video (built "
+    + "automatically ~5 min after the dawn window closes), so you get night-only timelapses that aren't cut off "
+    + "at midnight.",
+    selectField("capture.daylight_window.mode", ["day", "night"], {default: "day"})));
   sec.appendChild(fieldRow("Daylight buffer (minutes)",
-    "Widens the auto daylight window by this many minutes on each side — starts capturing this long before "
-    + "sunrise, stops this long after sunset. Only matters when Auto daylight window above is on.",
+    "In day mode, widens the window by this many minutes each side (start before sunrise, stop after sunset). "
+    + "In night mode it's the inverse — trims that much twilight off each end of the night. Only matters when "
+    + "Auto daylight window above is on.",
     numberField("capture.daylight_window.buffer_minutes", {default: 0})));
   sec.appendChild(fieldRow("Start time (HH:MM)", "Fixed daily start time for capture, e.g. \"05:30\". Empty "
     + "means capture all day. Ignored whenever Auto daylight window above is on.",


### PR DESCRIPTION
Adds `capture.daylight_window.mode: night` — the inverse of the daylight window.

## What it does
- Captures only the **dark hours** (complement of the sunrise/sunset window); `buffer_minutes` trims twilight off each end instead of extending it.
- A night **spans midnight** and is saved as **one continuous video**: frames bucket by a noon-to-noon logical day (timestamp shifted 12h), so an evening + the following morning share one folder and sort chronologically — no more clips cut at midnight.
- Since a night finishes at dawn, the fixed nightly timer can't build it. The **capture service triggers each night's build ~5 min after the window closes** (detached subprocess, non-blocking). The scheduled `daily` build is a no-op in night mode unless an explicit `--date` is passed.

## Verified
- `within_window` inversion (day vs night) across a daylight window.
- Noon-shift grouping + chronological ordering (evening/midnight/morning → one folder, correct order).
- `cmd_daily` night-skip on default, builds on explicit `--date`.
- Dawn-transition trigger fires exactly once, at boundary+5min, for the correct night date.
- Day-mode default build still resolves "yesterday" (no regression).
- Config page **Window mode** select renders and round-trips; validator rejects bad modes.

Part of the upcoming v0.2.0 (see CHANGELOG Unreleased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)