### PR TITLE
Publish multi-arch release images to GHCR

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,51 @@
+name: Publish release image
+
+# Build and push a multi-arch (amd64 + arm64) container image to GitHub
+# Container Registry whenever a version tag is pushed. amd64 covers x86 hosts;
+# arm64 covers Raspberry Pi and other ARM boards.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU (for arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `main`), and prompts between the release and `main` when run interactively.
   Override with `REOLAPSE_REF=` (a tag or `main`); `REOLAPSE_YES=1` takes the
   stable default non-interactively.
+- Docker: `docker compose` now runs a **pre-built multi-arch release image**
+  from `ghcr.io/seriesoftubez/reolapse` by default (`docker compose pull`);
+  building from source (`up -d --build`) still works. Release images
+  (amd64 + arm64) are published automatically on each version tag.
 
 ### Added
 - **Night mode** (`capture.daylight_window.mode: night`): capture only the dark

--- a/README.md
+++ b/README.md
@@ -171,12 +171,22 @@ cd reolapse
 cp config.example.yaml config.yaml   # edit: cameras, location, options
 cp .env.example .env                 # set REOLINK_PASSWORD
 
+docker compose pull && docker compose up -d   # runs the latest release image
+```
+
+This pulls a pre-built multi-arch image (amd64 + arm64, so it works on a
+Raspberry Pi) from `ghcr.io/seriesoftubez/reolapse`. Pin a version with
+`REOLAPSE_TAG=0.2.0 docker compose up -d`, or **build from source** instead —
+handy for local changes or unreleased code:
+
+```bash
 docker compose up -d --build
 ```
 
 Open <http://localhost:8080>. Three services start: `capture` (continuous),
 `scheduler` (nightly/weekly builds), and `web`. Keep `storage.root: ./data` in
-`config.yaml` so data lands on the Docker volume.
+`config.yaml` so data lands on the Docker volume. To upgrade later, see
+[Upgrading](#upgrading).
 
 ## Install on a Linux VM (systemd)
 
@@ -305,10 +315,13 @@ with `REOLAPSE_REF=main`.
 **Docker:**
 
 ```bash
-cd /path/to/reolapse && git pull && docker compose up -d --build
+cd /path/to/reolapse
+git pull                                # refresh compose file + docs
+docker compose pull && docker compose up -d   # or: up -d --build to build from source
 ```
 
-The `data` volume survives the rebuild.
+The `data` volume survives across both. (`git pull` just updates the compose
+file; the actual app comes from the pulled image or a local build.)
 
 Releases are tagged and listed on the
 [Releases page](https://github.com/SeriesOfTubez/reolapse/releases). The running

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,12 @@
 #
 #   cp config.example.yaml config.yaml   # then edit
 #   cp .env.example .env                 # then set REOLINK_PASSWORD
+#
+# Run a published release image (recommended):
+#   docker compose pull && docker compose up -d
+#   # pin a version with:  REOLAPSE_TAG=0.2.0 docker compose up -d
+#
+# …or build from source instead (for local changes / unreleased code):
 #   docker compose up -d --build
 #
 # In config.yaml keep `storage: root: ./data` so data lands on the volume.
@@ -11,7 +17,7 @@
 services:
   capture:
     build: .
-    image: reolapse:latest
+    image: ghcr.io/seriesoftubez/reolapse:${REOLAPSE_TAG:-latest}
     command: python capture.py --loop
     env_file: .env
     volumes:
@@ -23,7 +29,7 @@ services:
 
   scheduler:
     build: .
-    image: reolapse:latest
+    image: ghcr.io/seriesoftubez/reolapse:${REOLAPSE_TAG:-latest}
     command: python scheduler.py
     env_file: .env
     volumes:
@@ -37,7 +43,7 @@ services:
 
   web:
     build: .
-    image: reolapse:latest
+    image: ghcr.io/seriesoftubez/reolapse:${REOLAPSE_TAG:-latest}
     command: python webapp/app.py
     env_file: .env
     ports:


### PR DESCRIPTION
Closes the gap where Docker users could only build from source (ignoring releases).

- **New workflow** `release-image.yml`: on each `v*` tag, builds **linux/amd64 + linux/arm64** (Pi-friendly) and pushes to `ghcr.io/<repo>` as `:x.y.z`, `:x.y`, `:latest`. Uses the built-in `GITHUB_TOKEN` (`packages: write`) — no secrets.
- **docker-compose** points `image:` at the GHCR image (`REOLAPSE_TAG`-pinnable): `docker compose pull && up -d` runs a release; `up -d --build` still builds from source.
- README Docker quick-start + Upgrading updated.

**Note:** the workflow fires on tag push, so it's first exercised when we cut the next release (v0.2.0). After the first publish, the ghcr package visibility needs to be set to **public** once (one-time, in the package settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)