### PR TITLE
Build-status indicator for daily video builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (amd64 + arm64) are published automatically on each version tag.
 
 ### Added
+- **Build status indicator**: the web UI header shows "Building videos…" while a
+  daily build is running (the build writes `data/build_status.json`, the UI
+  polls it), and refreshes the video list when a build finishes.
 - **Night mode** (`capture.daylight_window.mode: night`): capture only the dark
   hours (the inverse of the daylight window). A night spans midnight and is
   saved as one continuous video — frames bucket by a noon-to-noon day — and the

--- a/build_timelapse.py
+++ b/build_timelapse.py
@@ -12,6 +12,7 @@ Yearly video (rebuild any time; uses frames archived by the daily build):
 """
 
 import argparse
+import contextlib
 import datetime as dt
 import json
 import logging
@@ -23,12 +24,43 @@ import tempfile
 import time
 from pathlib import Path
 
-from common import (load_config, local_today, snapshots_dir, tzinfo_for,
-                    videos_dir, yearly_frames_dir)
+from common import (build_status_path, load_config, local_today, snapshots_dir,
+                    tzinfo_for, videos_dir, yearly_frames_dir)
 
 log = logging.getLogger("timelapse")
 
 MIN_FRAMES = 2
+
+
+@contextlib.contextmanager
+def build_status(cfg, kind, label):
+    """Mark a build running in data/build_status.json for the duration, then
+    idle, so the web UI can show a "building…" indicator. Best-effort — a
+    status-write failure never affects the build itself."""
+    path = build_status_path(cfg)
+    started = time.time()
+
+    def _write(payload):
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(payload), encoding="utf-8")
+        except OSError:
+            log.debug("could not write build status", exc_info=True)
+
+    _write({"state": "running", "kind": kind, "label": str(label),
+            "started_epoch": started,
+            "started_at": dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")})
+    ok = True
+    try:
+        yield
+    except BaseException:
+        ok = False
+        raise
+    finally:
+        _write({"state": "idle", "last": {
+            "kind": kind, "label": str(label), "ok": ok,
+            "seconds": round(time.time() - started, 1),
+            "finished_at": dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}})
 
 
 def require_ffmpeg():
@@ -213,34 +245,35 @@ def cmd_daily(cfg, args):
         return
     date = resolve_date(args.date, tz)
     season = season_metadata(cfg, date)
-    for cam in selected_cameras(cfg, args.camera):
-        frames = day_frames(cfg, cam["name"], date)
-        if len(frames) < MIN_FRAMES:
-            log.warning("%s: only %d frame(s) for %s, skipping", cam["name"], len(frames), date)
-            continue
-        d = cfg["daily_video"]
-        out = videos_dir(cfg) / cam["name"] / "daily" / f"{date.isoformat()}.mp4"
-        build_video(
-            frames, out,
-            fps=d["fps"], crf=d["crf"],
-            deflicker_size=d.get("deflicker_size", 0),
-            max_height=d.get("max_height", 0),
-            preset=d.get("preset", "medium"),
-            metadata=season,
-        )
-        archive_yearly_frames(cfg, cam["name"], date, frames)
-
-    try:
-        build_event_videos(cfg, date, args.camera)
-    except Exception:
-        log.exception("event video build failed (daily videos are unaffected)")
-
-    try:
+    with build_status(cfg, "daily", date):
         for cam in selected_cameras(cfg, args.camera):
-            prune_daily_videos(cfg, cam["name"])
-        prune_event_videos(cfg)
-    except Exception:
-        log.exception("video retention pruning failed (build is unaffected)")
+            frames = day_frames(cfg, cam["name"], date)
+            if len(frames) < MIN_FRAMES:
+                log.warning("%s: only %d frame(s) for %s, skipping", cam["name"], len(frames), date)
+                continue
+            d = cfg["daily_video"]
+            out = videos_dir(cfg) / cam["name"] / "daily" / f"{date.isoformat()}.mp4"
+            build_video(
+                frames, out,
+                fps=d["fps"], crf=d["crf"],
+                deflicker_size=d.get("deflicker_size", 0),
+                max_height=d.get("max_height", 0),
+                preset=d.get("preset", "medium"),
+                metadata=season,
+            )
+            archive_yearly_frames(cfg, cam["name"], date, frames)
+
+        try:
+            build_event_videos(cfg, date, args.camera)
+        except Exception:
+            log.exception("event video build failed (daily videos are unaffected)")
+
+        try:
+            for cam in selected_cameras(cfg, args.camera):
+                prune_daily_videos(cfg, cam["name"])
+            prune_event_videos(cfg)
+        except Exception:
+            log.exception("video retention pruning failed (build is unaffected)")
 
     elapsed = time.time() - start
     log.info("daily build finished in %.1f min", elapsed / 60)

--- a/common.py
+++ b/common.py
@@ -6,8 +6,10 @@ loaded first (without overriding real environment variables, so Docker /
 systemd values win). See config.example.yaml and .env.example.
 """
 
+import json
 import os
 import re
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -103,6 +105,25 @@ def load_config(config_path=None):
         root = (config_path.parent / root).resolve()
     cfg["storage"]["root"] = root
     return cfg
+
+
+def build_status_path(cfg) -> Path:
+    return cfg["storage"]["root"] / "build_status.json"
+
+
+def read_build_status(cfg, stale_seconds=3600) -> dict:
+    """Current video-build status, written by build_timelapse and read by the
+    web UI (they share the data dir). Returns {"state": "idle"} if nothing has
+    run, and treats a "running" status older than stale_seconds as idle so a
+    build killed mid-run (no clean exit) doesn't leave the UI stuck."""
+    try:
+        data = json.loads(build_status_path(cfg).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"state": "idle"}
+    if data.get("state") == "running" and \
+            time.time() - data.get("started_epoch", 0) > stale_seconds:
+        return {"state": "idle", "last": data.get("last")}
+    return data
 
 
 def snapshots_dir(cfg) -> Path:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -27,7 +27,8 @@ import yaml
 from flask import Flask, abort, jsonify, request, send_from_directory
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from common import APP_VERSION, DEFAULT_CONFIG, load_config, tzinfo_for, videos_dir  # noqa: E402
+from common import (APP_VERSION, DEFAULT_CONFIG, load_config,  # noqa: E402
+                    read_build_status, tzinfo_for, videos_dir)
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -443,6 +444,12 @@ def create_app(cfg, config_path=None):
             "warnings": config_warnings(cfg),
             "version": APP_VERSION,
         })
+
+    @app.get("/api/build-status")
+    def build_status():
+        # Polled by the UI to show a "building videos…" indicator. Cheap: reads
+        # one small JSON file the build process writes.
+        return jsonify(read_build_status(state["cfg"]))
 
     @app.get("/api/storage")
     def storage():

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -80,6 +80,10 @@
     letter-spacing: 0.2px;
   }
   .brand .version { color: var(--text-3); font-size: var(--fs-xs); align-self: flex-end; margin-bottom: 3px; }
+  .build-indicator { display: flex; align-items: center; gap: 6px; font-size: var(--fs-xs); color: var(--accent); white-space: nowrap; }
+  .build-indicator[hidden] { display: none; }
+  .build-spin { width: 10px; height: 10px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; display: inline-block; animation: build-spin 0.8s linear infinite; }
+  @keyframes build-spin { to { transform: rotate(360deg); } }
 
   .pills { display: flex; gap: var(--space-2); flex-wrap: wrap; }
   .pill {
@@ -444,6 +448,7 @@
     <button class="pill" data-type="storage">Storage</button>
     <button class="pill" data-type="config">Config</button>
   </div>
+  <div class="build-indicator" id="build-indicator" hidden></div>
 </header>
 <div id="warnings"></div>
 <main>
@@ -1659,7 +1664,33 @@ function buildWebappSection() {
   return sec;
 }
 
+// Poll for video-build activity and show a header indicator while a build runs.
+let _lastBuildState = null;
+async function pollBuildStatus() {
+  const el = document.getElementById("build-indicator");
+  if (!el) return;
+  try {
+    const s = await (await fetch("/api/build-status")).json();
+    const running = s.state === "running";
+    if (running) {
+      const kind = s.kind ? s.kind + " " : "";
+      el.innerHTML = `<span class="build-spin"></span> Building ${kind}videos…`;
+      el.hidden = false;
+    } else {
+      el.hidden = true;
+    }
+    // A build just finished — refresh the video list so the new one shows up
+    // (skip while the user is on the Config page to avoid interrupting edits).
+    if (_lastBuildState === "running" && !running && state.type !== "config") {
+      load();
+    }
+    _lastBuildState = s.state;
+  } catch (e) { /* transient; try again next tick */ }
+}
+setInterval(pollBuildStatus, 8000);
+
 load();
+pollBuildStatus();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Adds a visible indicator that a video build is in progress.

- The build writes `data/build_status.json` (running → idle) around `cmd_daily`, best-effort, with a staleness guard so a killed build doesn't leave the UI stuck.
- New `GET /api/build-status`; the web UI polls it every 8s and shows a **"Building daily videos…"** spinner in the header, then refreshes the video list when the build finishes.
- Covers scheduled, manual, and capture-triggered **night** builds (all go through `cmd_daily`).

Verified: status lifecycle (idle → running → idle + `last` summary), staleness handling, and the header indicator showing/hiding in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)