### PR TITLE
Publish a Docker :edge image from main

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,11 +1,13 @@
-name: Publish release image
+name: Publish image
 
-# Build and push a multi-arch (amd64 + arm64) container image to GitHub
-# Container Registry whenever a version tag is pushed. amd64 covers x86 hosts;
-# arm64 covers Raspberry Pi and other ARM boards.
+# Build and push multi-arch (amd64 + arm64) container images to GHCR:
+#   * on a version tag  -> :x.y.z, :x.y, :latest   (stable releases)
+#   * on push to main   -> :edge                    (latest development code)
+# amd64 covers x86 hosts; arm64 covers Raspberry Pi and other ARM boards.
 
 on:
   push:
+    branches: [main]
     tags:
       - "v*"
 
@@ -36,10 +38,14 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+          # No implicit "latest"; we add it explicitly for tags only, so a
+          # push to main only moves :edge and never clobbers :latest.
+          flavor: latest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=edge,branch=main
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Docker `:edge` image: every push to `main` now publishes a multi-arch
+  `ghcr.io/seriesoftubez/reolapse:edge` image (latest development code), the
+  Docker parallel to `install.sh`'s `main` option. Run it with
+  `REOLAPSE_TAG=edge docker compose pull && docker compose up -d`.
+
 ## [0.2.0] - 2026-07-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ docker compose pull && docker compose up -d   # runs the latest release image
 ```
 
 This pulls a pre-built multi-arch image (amd64 + arm64, so it works on a
-Raspberry Pi) from `ghcr.io/seriesoftubez/reolapse`. Pin a version with
-`REOLAPSE_TAG=0.2.0 docker compose up -d`, or **build from source** instead —
-handy for local changes or unreleased code:
+Raspberry Pi) from `ghcr.io/seriesoftubez/reolapse`. `REOLAPSE_TAG` selects
+which: `latest` (newest release, default), a pinned version like `0.2.0`, or
+`edge` (latest development code from `main`) — e.g.
+`REOLAPSE_TAG=edge docker compose pull && docker compose up -d`. Or **build
+from source** instead, handy for local changes or unreleased code:
 
 ```bash
 docker compose up -d --build


### PR DESCRIPTION
Parity with `install.sh` offering `main`: Docker now gets an `:edge` image too.

- Renames `release-image.yml` → `publish-image.yml`; adds a `push: branches: [main]` trigger that builds multi-arch `ghcr.io/<repo>:edge` (latest dev code).
- Tag pushes still produce `:x.y.z`, `:x.y`, `:latest`. `latest` is now added explicitly **for tags only** (`flavor: latest=false`), so a push to main only moves `:edge` and never clobbers `:latest`.
- Docs: `REOLAPSE_TAG=edge docker compose pull` documented in the README; CHANGELOG under Unreleased.

Note: this adds a multi-arch (incl. emulated arm64) build to each merge to main — a few minutes of CI per merge. Easy to trim edge to amd64-only later if that's noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)