### PR TITLE
Scan published images with Trivy before pushing

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -47,6 +47,25 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
             type=edge,branch=main
 
+      # Build amd64 locally first and scan it, so a vulnerable image is never
+      # pushed. The multi-arch push below reuses this build's cache (same
+      # buildx builder), so arm64 is the only extra work. amd64 and arm64 share
+      # the same alpine + pip packages, so scanning amd64 covers the CVE surface
+      # — matching the image scan in security.yml.
+      - name: Build amd64 image for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: reolapse:scan
+
+      - name: Install Trivy
+        run: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Scan image (fail on fixable HIGH/CRITICAL)
+        run: trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 reolapse:scan
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+- Published container images are now **Trivy-scanned before being pushed** to
+  GHCR — the publish workflow builds amd64, fails on any fixable HIGH/CRITICAL
+  CVE, and only then builds and pushes the multi-arch image. Gates both release
+  and `:edge` publishes at publish time (in addition to the existing scan on
+  every push/PR to `main`).
+
 ### Added
 - Docker `:edge` image: every push to `main` now publishes a multi-arch
   `ghcr.io/seriesoftubez/reolapse:edge` image (latest development code), the


### PR DESCRIPTION
Closes the gap where `publish-image.yml` pushed images without a scan gate.

- Builds amd64 (`load: true`) → **Trivy image scan** (HIGH/CRITICAL, `--ignore-unfixed`, same settings as `security.yml`) → then the multi-arch build-and-push. If the scan finds a fixable HIGH/CRITICAL CVE, the job fails **before** anything is pushed.
- Gates both **release** (`v*` tags) and **`:edge`** (main) publishes at publish time. The multi-arch push reuses the amd64 build cache (same buildx builder), so arm64 is the only extra build work.
- amd64 and arm64 share the same alpine + pip packages, so the amd64 scan covers the CVE surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)