### PR TITLE
Per-camera daylight windows and capture intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every push/PR to `main`).
 
 ### Added
+- **Per-camera capture schedules.** A camera can now set its own
+  `daylight_window` (`enabled`/`mode`/`buffer_minutes`) and `interval_seconds`,
+  each falling back to the global `capture` settings independently. This lets a
+  single camera record the dark hours — overnight wildlife, a moonrise — while
+  the rest keep shooting daylight. A camera can enable its own window while the
+  global one is off, or opt out while it is on. Night frames bucket by the
+  noon-to-noon day **per camera**, so a night camera in a daytime setup still
+  produces one continuous video instead of two halves split at midnight, and its
+  build is triggered at its own dawn scoped to just that camera. Editable from
+  the Config page under each camera's **Capture schedule**.
 - Docker `:edge` image: every push to `main` now publishes a multi-arch
   `ghcr.io/seriesoftubez/reolapse:edge` image (latest development code), the
   Docker parallel to `install.sh`'s `main` option. Run it with

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ not: reference them as `${VAR}` and put the values in `.env`. Highlights:
 |---|---|
 | `cameras[].host` / `channel` | Camera IP + `0`, or NVR IP + channel number |
 | `cameras[].ptz_home` | Quarantine frames taken off a PTZ camera's home position |
+| `cameras[].daylight_window` | Per-camera day/night schedule; each key falls back to `capture.daylight_window` — see [Per-camera schedules](#per-camera-schedules) |
+| `cameras[].interval_seconds` | Per-camera capture cadence; falls back to `capture.interval_seconds` |
 | `capture.timezone` | IANA timezone for capture timing/day boundaries; blank auto-detects from location, else falls back to the host clock |
 | `capture.interval_seconds` | Base capture cadence (default 60, minimum 10) |
 | `capture.start_time`/`end_time` | Optional fixed daily capture window |
@@ -645,6 +647,37 @@ window closes at sunrise**. (A manual build still works:
 Night mode needs a location set (`events.zip` or `latitude`/`longitude`), same
 as the daylight window. Leave `yearly.video_window` empty when using it — a
 daylight-hours filter makes no sense for night frames.
+
+### Per-camera schedules
+
+Everything above can be set **per camera**, so one camera can watch the dark
+hours while the rest shoot daylight — a yard camera logging which animals visit
+overnight, or one framing a moonrise, without changing what the others do:
+
+```yaml
+cameras:
+  - name: wildlife
+    # ...host, credentials, etc...
+    interval_seconds: 300     # optional; falls back to capture.interval_seconds
+    daylight_window:
+      enabled: true
+      mode: night
+      buffer_minutes: 30
+```
+
+Each key falls back to the global `capture.daylight_window` **independently**,
+so `mode: night` alone inherits the global buffer. The two are resolved
+separately, so a camera can enable its own window while the global one is off —
+or set `enabled: false` to opt out while the global one is on.
+
+A night camera builds its own video at **its** dawn, scoped to just that camera;
+the others build on the normal nightly timer. All of this is editable from the
+Config page under each camera's **Capture schedule**.
+
+Note that covering the dark hours roughly **doubles** how long that camera is
+capturing versus daylight-only. `interval_seconds` on the camera is the simplest
+way to hold disk use flat — a night camera at 300s writes a fifth as many frames
+per hour as one at 60s. See [Storage estimates](#storage-estimates).
 
 ## Security
 

--- a/capture.py
+++ b/capture.py
@@ -22,7 +22,8 @@ import requests
 import urllib3
 
 import events
-from common import (APP_ROOT, APP_VERSION, load_config, local_now, local_today,
+from common import (APP_ROOT, APP_VERSION, camera_daylight_config,
+                    camera_interval_seconds, load_config, local_now, local_today,
                     snapshots_dir, tzinfo_for, videos_dir)
 
 # A "night" spans midnight, so night frames are bucketed by a noon-to-noon
@@ -93,14 +94,18 @@ class DaylightWindow:
     per day and caches it — capture ticks call this far more often than the
     sun rises.
 
+    One instance per camera: settings come from camera_daylight_config, so a
+    camera can run night mode while the rest of the setup stays on daylight.
+
     Uses the same location config as weather/lunar tagging (events.zip or
     latitude/longitude), independent of whether either of those is enabled.
     Fails open (captures all day) if location or the sunrise/sunset lookup
     is unavailable, same policy as the rest of capture.py's checks.
     """
 
-    def __init__(self, cfg, tz=None):
-        self.cfg = cfg["capture"].get("daylight_window") or {}
+    def __init__(self, cfg, tz=None, cam=None):
+        self.cfg = camera_daylight_config(cfg, cam or {})
+        self.label = (cam or {}).get("name", "global")
         self.enabled = bool(self.cfg.get("enabled"))
         # "day" captures inside the sunrise/sunset window; "night" captures its
         # complement (the dark hours), which spans midnight.
@@ -110,6 +115,10 @@ class DaylightWindow:
         self.tz = tz
         self._cached_date = None
         self._window = (None, None)
+
+    @property
+    def night(self) -> bool:
+        return self.enabled and self.mode == "night"
 
     def window_for(self, today):
         if today != self._cached_date:
@@ -123,7 +132,8 @@ class DaylightWindow:
             lat, lon = events.resolve_location(self.events_cfg)
             sunrise, sunset = events.sunrise_sunset(today, lat, lon, self.ephem_dir, self.tz)
         except Exception as exc:
-            log.warning("daylight window unavailable, capturing all day: %s", exc)
+            log.warning("%s: daylight window unavailable, capturing all day: %s",
+                        self.label, exc)
             return None, None
         if sunrise:
             sunrise = (dt.datetime.combine(today, sunrise)
@@ -131,7 +141,7 @@ class DaylightWindow:
         if sunset:
             sunset = (dt.datetime.combine(today, sunset)
                       + dt.timedelta(minutes=buffer_min)).time()
-        log.info("daylight window for %s: %s - %s", today,
+        log.info("%s: daylight window for %s: %s - %s", self.label, today,
                  sunrise.strftime("%H:%M") if sunrise else "n/a",
                  sunset.strftime("%H:%M") if sunset else "n/a")
         return sunrise, sunset
@@ -271,21 +281,35 @@ def prune_old_snapshots(cfg, tz=None):
             log.info("pruned snapshots %s/%s", cam_dir.name, day_dir.name)
 
 
-def run_once(cfg, conditions=None, daylight=None, tz=None):
+def run_once(cfg, conditions=None, windows=None, tz=None, due=None):
+    """Capture one frame per due camera.
+
+    Each camera is gated on its own daylight window, so a night camera and a
+    daytime one can coexist in the same tick. `due` optionally limits the run
+    to a subset of camera names (used by the loop for per-camera intervals);
+    None means every camera.
+    """
     now = local_now(tz)
     capture_cfg = cfg["capture"]
-    if not within_window(now, capture_cfg, daylight):
-        log.debug("outside capture window, skipping")
-        return
-
-    # In night mode, bucket by the noon-to-noon logical day so a night's
-    # evening + following-morning frames share one folder and sort in order.
-    night = bool(daylight and daylight.enabled and daylight.mode == "night")
-    capture_dt = (now - NIGHT_DAY_SHIFT) if night else now
+    windows = windows or {}
 
     tags = sorted(conditions.tags) if conditions else []
     out_root = snapshots_dir(cfg)
     for cam in cfg["cameras"]:
+        name = cam["name"]
+        if due is not None and name not in due:
+            continue
+        daylight = windows.get(name)
+        if not within_window(now, capture_cfg, daylight):
+            log.debug("%s: outside capture window, skipping", name)
+            continue
+
+        # In night mode, bucket by the noon-to-noon logical day so a night's
+        # evening + following-morning frames share one folder and sort in
+        # order. This follows the camera, not the global setting, or a
+        # night camera in a daytime setup would still be cut at midnight.
+        capture_dt = (now - NIGHT_DAY_SHIFT) if (daylight and daylight.night) else now
+
         if not cam.get("verify_ssl", True):
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         quarantine = not ptz_at_home(cam, capture_cfg)
@@ -306,15 +330,20 @@ def run_once(cfg, conditions=None, daylight=None, tz=None):
                     log.error("%s: snapshot failed: %s", cam["name"], msg)
 
 
-def trigger_night_build(config_path, date):
+def trigger_night_build(config_path, date, camera=None):
     """Launch the daily build for a just-completed night as a detached process,
     so a slow ffmpeg run never stalls capture. build_timelapse handles its own
-    logging and failures; a bad build must not take capture down."""
+    logging and failures; a bad build must not take capture down.
+
+    Scoped to one camera: nights end at that camera's own dawn, and the other
+    cameras' videos are built on the normal daily schedule."""
     cmd = [sys.executable, str(APP_ROOT / "build_timelapse.py"),
            "daily", "--date", date.isoformat()]
+    if camera:
+        cmd += ["--camera", camera]
     if config_path:
         cmd += ["--config", str(config_path)]
-    log.info("night ended — launching build for %s", date)
+    log.info("%s: night ended — launching build for %s", camera or "all", date)
     try:
         subprocess.Popen(cmd)
     except Exception:
@@ -323,7 +352,6 @@ def trigger_night_build(config_path, date):
 
 def loop(cfg, config_path=None):
     configured_interval = cfg["capture"]["interval_seconds"]
-    base_interval = max(MIN_INTERVAL_SECONDS, configured_interval)
     if configured_interval < MIN_INTERVAL_SECONDS:
         log.warning("capture.interval_seconds=%s is below the %ds minimum — using %ds "
                     "(faster polling risks overloading the camera/NVR)",
@@ -331,40 +359,68 @@ def loop(cfg, config_path=None):
     tz = tzinfo_for(events.resolve_timezone(cfg))
     log.info("capture timezone: %s", tz.key if tz is not None else "host system default")
     conditions = Conditions(cfg)
-    daylight = DaylightWindow(cfg, tz)
-    night_mode = daylight.enabled and daylight.mode == "night"
-    if daylight.enabled and (cfg["capture"].get("start_time") or cfg["capture"].get("end_time")):
-        log.warning("capture.daylight_window is enabled; static start_time/end_time are ignored")
-    if night_mode:
-        log.info("night mode: capturing dark hours; each night's video is built "
-                 "~%d min after the window closes at dawn", NIGHT_BUILD_DELAY.seconds // 60)
+
+    # One window and one interval per camera, resolved once at startup.
+    windows = {cam["name"]: DaylightWindow(cfg, tz, cam) for cam in cfg["cameras"]}
+    intervals = {cam["name"]: camera_interval_seconds(cfg, cam, MIN_INTERVAL_SECONDS)
+                 for cam in cfg["cameras"]}
+    for cam in cfg["cameras"]:
+        name = cam["name"]
+        win = windows[name]
+        if win.enabled and (cfg["capture"].get("start_time") or cfg["capture"].get("end_time")):
+            log.warning("%s: daylight window is enabled; static start_time/end_time "
+                        "are ignored for this camera", name)
+        log.info("%s: %s mode, every %ds", name,
+                 win.mode if win.enabled else "all-day", intervals[name])
+    if any(w.night for w in windows.values()):
+        log.info("night mode active; each night's video is built ~%d min after "
+                 "that camera's window closes at dawn", NIGHT_BUILD_DELAY.seconds // 60)
+
     last_prune_day = None
-    was_in_window = None
-    pending_build_date = None
-    pending_build_at = None
+    # Per-camera night-build bookkeeping, keyed by camera name.
+    was_in_window = {}
+    pending_build = {}
+    # Which clock-aligned slot each camera last fired in, so cameras on
+    # different intervals stay aligned to the wall clock instead of drifting.
+    last_slot = {}
     while True:
         conditions.refresh()
         # Burst tags (storm/snow) shorten the interval; pick a burst interval
         # that divides the base one so burst frames stay clock-aligned too.
-        interval = conditions.interval(base_interval)
+        effective = {name: conditions.interval(secs) for name, secs in intervals.items()}
+        # Tick at the fastest camera's rate; slower ones simply aren't due yet.
+        tick = min(effective.values()) if effective else conditions.interval(MIN_INTERVAL_SECONDS)
         now = time.time()
-        time.sleep(interval - (now % interval))
-        run_once(cfg, conditions, daylight, tz)
+        time.sleep(tick - (now % tick))
+
+        now = time.time()
+        due = set()
+        for name, secs in effective.items():
+            slot = int(now // secs)
+            if last_slot.get(name) != slot:
+                last_slot[name] = slot
+                due.add(name)
+        if due:
+            run_once(cfg, conditions, windows, tz, due)
 
         now_local = local_now(tz)
-        if night_mode:
-            # When capture crosses from the night window into daylight at dawn,
-            # the night just finished — schedule its build a few minutes later.
-            in_window = within_window(now_local, cfg["capture"], daylight)
-            if was_in_window and not in_window:
-                pending_build_date = (now_local - NIGHT_DAY_SHIFT).date()
-                pending_build_at = now_local + NIGHT_BUILD_DELAY
-                log.info("night window closed; build for %s scheduled ~%s",
-                         pending_build_date, pending_build_at.strftime("%H:%M"))
-            if pending_build_date and now_local >= pending_build_at:
-                trigger_night_build(config_path, pending_build_date)
-                pending_build_date = pending_build_at = None
-            was_in_window = in_window
+        for name, win in windows.items():
+            if not win.night:
+                continue
+            # When a camera crosses from its night window into daylight at
+            # dawn, that night just finished — schedule its build shortly after.
+            in_window = within_window(now_local, cfg["capture"], win)
+            if was_in_window.get(name) and not in_window:
+                build_date = (now_local - NIGHT_DAY_SHIFT).date()
+                build_at = now_local + NIGHT_BUILD_DELAY
+                pending_build[name] = (build_date, build_at)
+                log.info("%s: night window closed; build for %s scheduled ~%s",
+                         name, build_date, build_at.strftime("%H:%M"))
+            pending = pending_build.get(name)
+            if pending and now_local >= pending[1]:
+                trigger_night_build(config_path, pending[0], camera=name)
+                pending_build.pop(name, None)
+            was_in_window[name] = in_window
 
         today = local_today(tz)
         if today != last_prune_day:
@@ -392,7 +448,8 @@ def main():
         tz = tzinfo_for(events.resolve_timezone(cfg))
         conditions = Conditions(cfg)
         conditions.refresh()
-        run_once(cfg, conditions, DaylightWindow(cfg, tz), tz)
+        windows = {cam["name"]: DaylightWindow(cfg, tz, cam) for cam in cfg["cameras"]}
+        run_once(cfg, conditions, windows, tz)
         prune_old_snapshots(cfg, tz)
 
 

--- a/common.py
+++ b/common.py
@@ -107,6 +107,41 @@ def load_config(config_path=None):
     return cfg
 
 
+DAYLIGHT_KEYS = ("enabled", "mode", "buffer_minutes")
+
+
+def camera_daylight_config(cfg, cam) -> dict:
+    """A camera's effective daylight window settings.
+
+    Each key falls back to the global capture.daylight_window independently, so
+    a camera can flip just the mode and inherit the buffer. A camera may also
+    enable its own window while the global one is off (the "one night camera in
+    an otherwise daytime setup" case) — the two are resolved separately.
+    Always returns a fresh dict; callers must never alias the global config.
+    """
+    merged = dict((cfg.get("capture") or {}).get("daylight_window") or {})
+    for key, value in ((cam.get("daylight_window") or {}).items()):
+        if key in DAYLIGHT_KEYS and value is not None:
+            merged[key] = value
+    return merged
+
+
+def camera_interval_seconds(cfg, cam, minimum=10) -> int:
+    """A camera's capture interval, falling back to the global one.
+
+    Lets a night camera poll less often than the daytime ones, so covering the
+    dark hours doesn't double what the setup writes to disk.
+    """
+    value = cam.get("interval_seconds")
+    if value is None:
+        value = (cfg.get("capture") or {}).get("interval_seconds")
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        value = minimum
+    return max(minimum, value)
+
+
 def build_status_path(cfg) -> Path:
     return cfg["storage"]["root"] / "build_status.json"
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,6 +53,26 @@ cameras:
   #     # tilt: 79
   #     tolerance: 10
 
+  # Example: a night camera in an otherwise daytime setup — say a yard camera
+  # watching for nocturnal animals, or one framing a moonrise. Any key left out
+  # falls back to capture.daylight_window below, and a camera can enable its own
+  # window even when the global one is off (or opt out when it is on).
+  # - name: wildlife
+  #   host: 192.168.1.52
+  #   channel: 0
+  #   username: admin
+  #   password: "${REOLINK_PASSWORD}"
+  #   https: true
+  #   verify_ssl: false
+  #   interval_seconds: 300   # slower than the global rate — covering the dark
+  #                           # hours roughly doubles a camera's capture time, so
+  #                           # this is the simplest way to hold disk use flat
+  #   daylight_window:
+  #     enabled: true
+  #     mode: night           # capture the dark hours only; the night spans
+  #                           # midnight and builds as ONE video at dawn
+  #     buffer_minutes: 30    # trim 30 min of twilight off each end
+
 capture:
   timezone: ""                # IANA name (e.g. "America/Chicago") for capture
                               # timing and day boundaries. Empty = auto-detect
@@ -63,6 +83,8 @@ capture:
   interval_seconds: 60        # one frame/minute -> ~48s daily video at 30 fps.
                               # Minimum 10s — faster polling can overload the
                               # camera/NVR (clamped, and rejected by the web UI).
+                              # Any camera may override this with its own
+                              # interval_seconds (see the wildlife example above).
   start_time: ""              # e.g. "05:30" to skip night frames; empty = all day
   end_time: ""                # e.g. "21:30". Ignored if daylight_window.enabled
   timeout_seconds: 15
@@ -70,6 +92,8 @@ capture:
                               # daily from sunrise/sunset instead of a fixed
                               # clock window — see the README section on IR
                               # and 24-hour timelapses for why this matters.
+                              # Applies to every camera that doesn't set its own
+                              # daylight_window (see the wildlife example above).
     enabled: false            # overrides start_time/end_time when true
     mode: day                 # "day" captures the daylight window; "night"
                               # captures its complement (dark hours). A night

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -170,6 +170,21 @@ def validate_config(cfg):
                     f"like \"${{VAR_NAME}}\" (never a literal secret) — set the real "
                     f"value in .env. Got: {pw!r}"
                 )
+            cam_dl = cam.get("daylight_window")
+            if cam_dl is not None and not isinstance(cam_dl, dict):
+                problems.append(f"cameras[{i}].daylight_window must be a mapping")
+            elif cam_dl:
+                mode = cam_dl.get("mode")
+                if mode is not None and str(mode).strip().lower() not in ("day", "night"):
+                    problems.append(f'cameras[{i}].daylight_window.mode must be "day" or "night"')
+            cam_interval = cam.get("interval_seconds")
+            if cam_interval is not None:
+                if isinstance(cam_interval, bool) or not isinstance(cam_interval, (int, float)):
+                    problems.append(f"cameras[{i}].interval_seconds must be a number")
+                elif cam_interval < MIN_INTERVAL_SECONDS:
+                    problems.append(
+                        f"cameras[{i}].interval_seconds must be at least {MIN_INTERVAL_SECONDS} "
+                        "(faster polling risks overloading the camera/NVR)")
 
     for section in REQUIRED_SECTIONS:
         if not isinstance(cfg.get(section), dict):

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -326,6 +326,24 @@
     margin-bottom: var(--space-3);
     line-height: 1.5;
   }
+  /* Nested group inside a camera card (e.g. its capture schedule). */
+  .cfg-subsection {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-3);
+    margin-top: var(--space-3);
+  }
+  .cfg-subsection h4 {
+    margin: 0 0 var(--space-2) 0;
+    font-size: var(--fs-sm);
+    font-weight: var(--fw-semibold);
+  }
+  .cfg-subsection .cfg-hint-block {
+    color: var(--text-2);
+    font-size: var(--fs-xs);
+    margin-bottom: var(--space-2);
+    line-height: 1.5;
+  }
   .cfg-row {
     display: flex;
     align-items: flex-start;
@@ -1283,6 +1301,8 @@ function renderCameraCards(list) {
       + "which would otherwise always fail this check.",
       checkboxField(`cameras.${i}.verify_ssl`, {default: false})));
 
+    card.appendChild(buildCameraScheduleSection(i));
+
     if (cam.ptz_home) {
       const hint = document.createElement("div");
       hint.className = "cfg-hint";
@@ -1295,6 +1315,63 @@ function renderCameraCards(list) {
 
     list.appendChild(card);
   });
+}
+
+// Per-camera capture schedule. Each field falls back to the global setting, so
+// the defaults shown here are the global ones — what this camera does today.
+// Touching a field pins it for this camera only.
+function buildCameraScheduleSection(i) {
+  const gEnabled = cfgGet("capture.daylight_window.enabled", false);
+  const gMode = cfgGet("capture.daylight_window.mode", "day");
+  const gBuffer = cfgGet("capture.daylight_window.buffer_minutes", 0);
+  const gInterval = cfgGet("capture.interval_seconds", 60);
+
+  const box = document.createElement("div");
+  box.className = "cfg-subsection";
+  const heading = document.createElement("h4");
+  heading.textContent = "Capture schedule";
+  box.appendChild(heading);
+  const intro = document.createElement("div");
+  intro.className = "cfg-hint-block";
+  intro.textContent = "These start out following the global capture settings. Change one and it "
+    + "applies to this camera only — useful for pointing a single camera at the dark hours "
+    + "(overnight wildlife, a moonrise) while the rest keep shooting daylight.";
+  box.appendChild(intro);
+
+  box.appendChild(fieldRow("Auto daylight window",
+    "Capture around real sunrise/sunset for this camera instead of a fixed clock window. "
+    + `Global setting is currently ${gEnabled ? "on" : "off"}.`,
+    checkboxField(`cameras.${i}.daylight_window.enabled`, {default: gEnabled})));
+
+  const modeRow = fieldRow("Window mode",
+    "\"day\" captures during daylight; \"night\" captures the opposite — the dark hours only. "
+    + "A night spans midnight and is saved as one continuous video (built automatically ~5 min "
+    + "after this camera's dawn window closes), so night videos aren't cut off at midnight.",
+    selectField(`cameras.${i}.daylight_window.mode`, ["day", "night"], {default: gMode}));
+  box.appendChild(modeRow);
+
+  const bufferRow = fieldRow("Daylight buffer (minutes)",
+    "In day mode, widens the window by this many minutes each side (start before sunrise, stop "
+    + "after sunset). In night mode it's the inverse — trims that much twilight off each end.",
+    numberField(`cameras.${i}.daylight_window.buffer_minutes`, {default: gBuffer, min: 0}));
+  box.appendChild(bufferRow);
+
+  box.appendChild(fieldRow("Capture interval (seconds)",
+    "How often to grab a frame from this camera. A night camera covering the dark hours adds "
+    + "roughly as many hours again as a daytime one, so a slower interval here is the simplest "
+    + `way to keep disk growth flat. Global setting is ${gInterval}s; minimum is 10s.`,
+    numberField(`cameras.${i}.interval_seconds`, {default: gInterval, min: 10})));
+
+  // Mode and buffer only mean anything while the daylight window is on.
+  const syncVisibility = (on) => {
+    modeRow.style.display = on ? "" : "none";
+    bufferRow.style.display = on ? "" : "none";
+  };
+  syncVisibility(cfgGet(`cameras.${i}.daylight_window.enabled`, gEnabled));
+  const toggle = box.querySelector('input[type="checkbox"]');
+  if (toggle) toggle.addEventListener("change", () => syncVisibility(toggle.checked));
+
+  return box;
 }
 
 function buildDiscoverySection(cameraList) {


### PR DESCRIPTION
Lets a single camera record the dark hours — overnight wildlife, a moonrise —
while the rest keep shooting daylight.

A camera can now set its own `daylight_window` (`enabled`/`mode`/`buffer_minutes`)
and `interval_seconds`, each falling back to the global `capture` settings
**independently**, so `mode: night` alone inherits the global buffer. The two are
resolved separately: a camera can enable its own window while the global one is
off, or opt out while it is on.

```yaml
cameras:
  - name: wildlife
    interval_seconds: 300
    daylight_window:
      enabled: true
      mode: night
      buffer_minutes: 30
```

## Why this isn't just a config change

Three decisions had to move from global to per-camera scope, or the setting
would resolve correctly and still do nothing:

- **`run_once` no longer early-returns on a single global window.** It gated
  every camera before the loop, so a night camera could never have been reached.
- **The noon-to-noon night bucketing follows the camera, not the global mode.**
  Otherwise a night camera in a daytime setup would still have its video cut in
  half at midnight — which is the entire point of night mode.
- **Night builds are tracked and triggered per camera**, scoped with `--camera`,
  so a night camera builds at its own dawn and the others build on the normal
  nightly timer.

The loop now ticks at the fastest camera's interval and marks each camera due on
its own clock-aligned slot, so mixed intervals stay aligned to the wall clock
instead of drifting.

## Backward compatibility

Verified as a behavioural no-op for any config without per-camera keys —
including the reference deployment, where all cameras resolve to all-day/60s
exactly as before.

## Verification

Beyond unit-level checks, the real `loop()` was driven across a simulated dawn
with a virtual clock: exactly one build fired, scoped to the night camera, dated
to the night that *ended* at that dawn rather than the calendar date. A full
round-trip was also exercised — edit in the web UI, save, read the YAML back
through the capture engine, confirm the resulting windows and buffers.

Config-page UI, validation (bad mode, sub-minimum interval), CHANGELOG, README,
and `config.example.yaml` all updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)