### PR TITLE
Fix upgrade.sh resolving an explicit REOLAPSE_REF against the local repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Docker parallel to `install.sh`'s `main` option. Run it with
   `REOLAPSE_TAG=edge docker compose pull && docker compose up -d`.
 
+### Fixed
+- `upgrade.sh` with an explicit **`REOLAPSE_REF` pointing at a branch** upgraded
+  to the wrong code, silently. The ref was used verbatim, but the preceding
+  fetch only updates remote-tracking refs — so `REOLAPSE_REF=main` reset to the
+  machine's *local* `main`, which is stale on a normal install (it resolved to
+  the **v0.1.0** commit on a box last upgraded at v0.1.0) and doesn't exist at
+  all on the shallow single-branch clone `install.sh` creates, where the upgrade
+  failed outright. The ref is now fetched by name first, which works for
+  branches, tags, and SHAs alike. Tag upgrades were unaffected.
+
 ## [0.2.0] - 2026-07-14
 
 ### Changed

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -47,11 +47,39 @@ preflight() {
   fi
 }
 
+# Echoes a revision that `git reset --hard` can use.
+#
+# An explicit REOLAPSE_REF used to be echoed verbatim, which quietly did the
+# wrong thing: the fetch above only updates remote-tracking refs and tags, so
+# REOLAPSE_REF=main reset to the machine's *local* main — stale, or absent
+# entirely on the shallow single-branch clone install.sh creates (`git clone
+# --branch <tag> --depth 1` implies --single-branch, so refs/remotes/origin/main
+# may never have existed). Fetching the ref by name fixes both cases and works
+# for branches, tags, and SHAs alike.
 pick_target() {
-  git -C "$DEST" fetch --tags --force --prune origin >/dev/null 2>&1
   if [ -n "${REOLAPSE_REF:-}" ]; then
-    echo "$REOLAPSE_REF"; return
+    local ref="$REOLAPSE_REF"
+    # Fetch by name first — the only form that reaches a branch the local
+    # clone has never tracked.
+    if git -C "$DEST" fetch --tags --force origin "$ref" >/dev/null 2>&1; then
+      git -C "$DEST" rev-parse FETCH_HEAD
+      return
+    fi
+    # Not fetchable by name (e.g. a raw SHA already present, or offline):
+    # fall back to whatever resolves locally, preferring the remote copy.
+    git -C "$DEST" fetch --tags --force --prune origin >/dev/null 2>&1
+    local candidate
+    for candidate in "origin/$ref" "$ref"; do
+      if git -C "$DEST" rev-parse -q --verify "$candidate^{commit}" >/dev/null 2>&1; then
+        git -C "$DEST" rev-parse "$candidate"
+        return
+      fi
+    done
+    err "Could not resolve REOLAPSE_REF='$ref' as a branch, tag, or commit."
+    return 1
   fi
+
+  git -C "$DEST" fetch --tags --force --prune origin >/dev/null 2>&1
   local latest_tag
   latest_tag="$(git -C "$DEST" tag -l 'v*' | sort -V | tail -1)"
   if [ -n "$latest_tag" ]; then
@@ -67,12 +95,14 @@ main() {
   trap 'err "Upgrade failed (line $LINENO). Your install was not changed beyond what already ran."' ERR
   preflight
 
-  local before target
+  local before target label
   before="$(cat "$DEST/VERSION" 2>/dev/null || echo unknown)"
   target="$(pick_target)"
-  info "Current version: $before  ->  upgrading to: $target"
+  # An explicit ref resolves to a bare SHA, so show what the user asked for.
+  label="${REOLAPSE_REF:-$target}"
+  info "Current version: $before  ->  upgrading to: $label"
 
-  info "Fetching and checking out $target…"
+  info "Fetching and checking out $label…"
   git -C "$DEST" reset --hard "$target"
 
   info "Reinstalling Python dependencies…"


### PR DESCRIPTION
`pick_target()` echoed an explicit `REOLAPSE_REF` verbatim, but the fetch before
it only updates remote-tracking refs and tags. So `REOLAPSE_REF=<branch>` reset
to the machine's **local** branch ref.

## Impact

| install shape | `REOLAPSE_REF=main` before | after |
|---|---|---|
| full clone, last upgraded at a tag | resolved `5204c1bf` — the **v0.1.0** commit, two releases behind, reporting success | tip of `main` |
| shallow single-branch clone from `install.sh` | **failed outright** — `refs/remotes/origin/main` never existed | tip of `main` |
| explicit tag (`REOLAPSE_REF=v0.2.0`) | correct | correct (unchanged) |

The first row is the bad one: a user asking for `main` got a silently outdated
install with no error. `git clone --branch <tag> --depth 1` implies
`--single-branch`, which is what produces the second row.

## Fix

Fetch the ref by name first and resolve `FETCH_HEAD` — the only form that
reaches a branch the local clone has never tracked, and it works for branches,
tags, and SHAs alike. Falls back to `origin/<ref>` then `<ref>` for a raw SHA
already present or an offline run, and now fails loudly rather than resetting to
the wrong thing.

`install.sh` already did this correctly (`rev-parse origin/$REF || rev-parse
$REF`); this brings `upgrade.sh` in line. The no-REF default path was already
correct and is untouched.

## Verification

Exercised `pick_target()` against three real repo shapes — shallow tag clone,
full clone with a stale local `main`, and an explicit tag — running the old and
new implementations side by side against a real clone and comparing resolved
SHAs. Results are the table above. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)