### PR TITLE
Per-camera opt-out from weather events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every push/PR to `main`).
 
 ### Added
+- **Per-camera event opt-out.** A camera can now set `events_enabled: false` to
+  ignore weather/lunar events entirely — it holds its own `interval_seconds`
+  through a storm instead of dropping to `events.burst_interval_seconds`, and no
+  event clips are built from its frames. For a camera the weather isn't visible
+  from (indoors, a doorway, a tight framing) the burst frames are just disk and
+  the clip is a video of nothing happening. The burst interval is now resolved
+  **per camera**, so the rest of the setup still bursts normally. Frames are
+  still tagged either way, so the metadata stays complete for the search/filter
+  features built on it. Defaults to true; existing configs are unaffected.
+  Editable from the Config page under each camera's **Weather events**.
 - **Per-camera capture schedules.** A camera can now set its own
   `daylight_window` (`enabled`/`mode`/`buffer_minutes`) and `interval_seconds`,
   each falling back to the global `capture` settings independently. This lets a

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ not: reference them as `${VAR}` and put the values in `.env`. Highlights:
 | `cameras[].ptz_home` | Quarantine frames taken off a PTZ camera's home position |
 | `cameras[].daylight_window` | Per-camera day/night schedule; each key falls back to `capture.daylight_window` — see [Per-camera schedules](#per-camera-schedules) |
 | `cameras[].interval_seconds` | Per-camera capture cadence; falls back to `capture.interval_seconds` |
+| `cameras[].events_enabled` | `false` makes a camera ignore events entirely — no burst capture, no event clips (default `true`) — see [Cameras that sit out events](#cameras-that-sit-out-events) |
 | `capture.timezone` | IANA timezone for capture timing/day boundaries; blank auto-detects from location, else falls back to the host clock |
 | `capture.interval_seconds` | Base capture cadence (default 60, minimum 10) |
 | `capture.start_time`/`end_time` | Optional fixed daily capture window |
@@ -678,6 +679,41 @@ Note that covering the dark hours roughly **doubles** how long that camera is
 capturing versus daylight-only. `interval_seconds` on the camera is the simplest
 way to hold disk use flat — a night camera at 300s writes a fifth as many frames
 per hour as one at 60s. See [Storage estimates](#storage-estimates).
+
+### Cameras that sit out events
+
+Not every camera can see the weather. One pointed indoors, at a doorway, or
+framed tight on a walkway gains nothing from a storm — the burst frames are just
+disk, and the event clip is a video of nothing happening. Set `events_enabled:
+false` and that camera ignores events entirely:
+
+```yaml
+cameras:
+  - name: front-door
+    # ...host, credentials, etc...
+    events_enabled: false     # default true; omit to participate normally
+```
+
+Two things change for that camera, and nothing else does:
+
+- **No burst capture.** It holds its own `interval_seconds` through a storm
+  instead of dropping to `events.burst_interval_seconds`. The other cameras
+  still burst — the interval is resolved per camera.
+- **No event videos.** The events build skips it, so it produces no
+  `<date>_<tag>.mp4` clips. Its daily and yearly videos are unaffected.
+
+Its frames are **still tagged** either way. The tag is metadata embedded in each
+JPEG, it costs nothing, and keeping it means the frame record stays complete for
+searching and filtering later — it's the capture rate and the video build that
+opt out, not the metadata.
+
+Event clips built *before* you turned this off stay on disk and keep expiring on
+the normal `events_video.retention_days` schedule — turning this off stops new
+clips, it doesn't delete old ones. (Rebuilding one of those past dates with
+`build_timelapse.py events --date ...` does drop that camera's clips for that
+date from the Events list, since the rebuild replaces the whole day's entries.)
+
+Editable from the Config page under each camera's **Weather events**.
 
 ## Security
 

--- a/build_timelapse.py
+++ b/build_timelapse.py
@@ -24,8 +24,9 @@ import tempfile
 import time
 from pathlib import Path
 
-from common import (build_status_path, load_config, local_today, snapshots_dir,
-                    tzinfo_for, videos_dir, yearly_frames_dir)
+from common import (build_status_path, camera_events_enabled, load_config,
+                    local_today, snapshots_dir, tzinfo_for, videos_dir,
+                    yearly_frames_dir)
 
 log = logging.getLogger("timelapse")
 
@@ -454,6 +455,9 @@ def build_event_videos(cfg, date, camera=None):
     season = season_metadata(cfg, date)
 
     for cam in selected_cameras(cfg, camera):
+        if not camera_events_enabled(cfg, cam):
+            log.info("%s: events_enabled is false, skipping event videos", cam["name"])
+            continue
         all_frames = day_frames(cfg, cam["name"], date)
         for tag in tags:
             for i, (start, end) in enumerate(tag_spans(cfg, date, tag)):

--- a/capture.py
+++ b/capture.py
@@ -23,8 +23,8 @@ import urllib3
 
 import events
 from common import (APP_ROOT, APP_VERSION, camera_daylight_config,
-                    camera_interval_seconds, load_config, local_now, local_today,
-                    snapshots_dir, tzinfo_for, videos_dir)
+                    camera_events_enabled, camera_interval_seconds, load_config,
+                    local_now, local_today, snapshots_dir, tzinfo_for, videos_dir)
 
 # A "night" spans midnight, so night frames are bucketed by a noon-to-noon
 # logical day (shift the timestamp back 12h). That makes one evening + the
@@ -82,7 +82,15 @@ class Conditions:
             with open(self.log_dir / f"{now:%Y-%m-%d}.jsonl", "a", encoding="utf-8") as f:
                 f.write(json.dumps(entry) + "\n")
 
-    def interval(self, base_seconds):
+    def interval(self, base_seconds, events_enabled=True):
+        """The effective interval for one camera: shortened to the burst
+        interval while a burst tag is active, otherwise its base interval.
+
+        A camera with events_enabled: false never bursts — it holds its base
+        interval through the storm, since the weather isn't visible from it.
+        """
+        if not events_enabled:
+            return base_seconds
         burst_tags = set(self.wcfg.get("burst_tags") or [])
         if burst_tags & set(self.tags):
             return max(MIN_INTERVAL_SECONDS, self.wcfg.get("burst_interval_seconds", 10))
@@ -293,6 +301,10 @@ def run_once(cfg, conditions=None, windows=None, tz=None, due=None):
     capture_cfg = cfg["capture"]
     windows = windows or {}
 
+    # Tags are embedded on every camera's frames, including cameras with
+    # events_enabled: false. The opt-out governs capture *rate* and video
+    # builds, not metadata — the JPEG comment costs nothing and keeps the
+    # frame record complete for the search/filter features built on it.
     tags = sorted(conditions.tags) if conditions else []
     out_root = snapshots_dir(cfg)
     for cam in cfg["cameras"]:
@@ -364,14 +376,16 @@ def loop(cfg, config_path=None):
     windows = {cam["name"]: DaylightWindow(cfg, tz, cam) for cam in cfg["cameras"]}
     intervals = {cam["name"]: camera_interval_seconds(cfg, cam, MIN_INTERVAL_SECONDS)
                  for cam in cfg["cameras"]}
+    events_on = {cam["name"]: camera_events_enabled(cfg, cam) for cam in cfg["cameras"]}
     for cam in cfg["cameras"]:
         name = cam["name"]
         win = windows[name]
         if win.enabled and (cfg["capture"].get("start_time") or cfg["capture"].get("end_time")):
             log.warning("%s: daylight window is enabled; static start_time/end_time "
                         "are ignored for this camera", name)
-        log.info("%s: %s mode, every %ds", name,
-                 win.mode if win.enabled else "all-day", intervals[name])
+        log.info("%s: %s mode, every %ds%s", name,
+                 win.mode if win.enabled else "all-day", intervals[name],
+                 "" if events_on[name] else " (ignores events: no burst, no event videos)")
     if any(w.night for w in windows.values()):
         log.info("night mode active; each night's video is built ~%d min after "
                  "that camera's window closes at dawn", NIGHT_BUILD_DELAY.seconds // 60)
@@ -387,7 +401,10 @@ def loop(cfg, config_path=None):
         conditions.refresh()
         # Burst tags (storm/snow) shorten the interval; pick a burst interval
         # that divides the base one so burst frames stay clock-aligned too.
-        effective = {name: conditions.interval(secs) for name, secs in intervals.items()}
+        # Resolved per camera, so a camera that ignores events keeps its own
+        # interval while the rest burst.
+        effective = {name: conditions.interval(secs, events_on.get(name, True))
+                     for name, secs in intervals.items()}
         # Tick at the fastest camera's rate; slower ones simply aren't due yet.
         tick = min(effective.values()) if effective else conditions.interval(MIN_INTERVAL_SECONDS)
         now = time.time()

--- a/common.py
+++ b/common.py
@@ -142,6 +142,23 @@ def camera_interval_seconds(cfg, cam, minimum=10) -> int:
     return max(minimum, value)
 
 
+def camera_events_enabled(cfg, cam) -> bool:
+    """Whether a camera participates in weather/lunar events at all.
+
+    False means it ignores them entirely: it holds its own interval through a
+    burst instead of speeding up, and no event videos are built from its
+    frames. That's the right setting for a camera the weather isn't visible
+    from — indoors, a doorway, a tight framing — where burst frames are just
+    disk and an event clip is a video of nothing happening.
+
+    Defaults to True; omit the key to participate normally. Takes cfg for
+    signature symmetry with the other per-camera helpers (there's no global
+    counterpart to fall back to — events are configured under `events`).
+    """
+    value = cam.get("events_enabled")
+    return True if value is None else bool(value)
+
+
 def build_status_path(cfg) -> Path:
     return cfg["storage"]["root"] / "build_status.json"
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -73,6 +73,21 @@ cameras:
   #                           # midnight and builds as ONE video at dawn
   #     buffer_minutes: 30    # trim 30 min of twilight off each end
 
+  # Example: a camera the weather isn't visible from — indoors, a doorway, a
+  # tight framing. events_enabled: false makes it ignore events entirely: it
+  # holds its own interval instead of speeding up to burst_interval_seconds
+  # during a storm, and no event clips are built from its frames. Its frames
+  # are still tagged, so the metadata stays complete. Defaults to true; leave
+  # the key out for a camera that should participate normally.
+  # - name: front-door
+  #   host: 192.168.1.50
+  #   channel: 3
+  #   username: admin
+  #   password: "${REOLINK_PASSWORD}"
+  #   https: true
+  #   verify_ssl: false
+  #   events_enabled: false
+
 capture:
   timezone: ""                # IANA name (e.g. "America/Chicago") for capture
                               # timing and day boundaries. Empty = auto-detect

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -185,6 +185,9 @@ def validate_config(cfg):
                     problems.append(
                         f"cameras[{i}].interval_seconds must be at least {MIN_INTERVAL_SECONDS} "
                         "(faster polling risks overloading the camera/NVR)")
+            cam_events = cam.get("events_enabled")
+            if cam_events is not None and not isinstance(cam_events, bool):
+                problems.append(f"cameras[{i}].events_enabled must be true or false")
 
     for section in REQUIRED_SECTIONS:
         if not isinstance(cfg.get(section), dict):

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -1302,6 +1302,7 @@ function renderCameraCards(list) {
       checkboxField(`cameras.${i}.verify_ssl`, {default: false})));
 
     card.appendChild(buildCameraScheduleSection(i));
+    card.appendChild(buildCameraEventsSection(i));
 
     if (cam.ptz_home) {
       const hint = document.createElement("div");
@@ -1370,6 +1371,42 @@ function buildCameraScheduleSection(i) {
   syncVisibility(cfgGet(`cameras.${i}.daylight_window.enabled`, gEnabled));
   const toggle = box.querySelector('input[type="checkbox"]');
   if (toggle) toggle.addEventListener("change", () => syncVisibility(toggle.checked));
+
+  return box;
+}
+
+// Per-camera opt-out from weather/lunar events. Kept out of the schedule
+// section above because it isn't a schedule — it decides whether this camera
+// reacts to events at all.
+function buildCameraEventsSection(i) {
+  const anyEvents = cfgGet("events.weather_enabled", false)
+    || cfgGet("events.lunar_enabled", false)
+    || cfgGet("events.season_enabled", false);
+  const burstTags = cfgGet("events.burst_tags", []) || [];
+  const tagList = burstTags.length ? burstTags.join(" or ") : "a burst";
+
+  const box = document.createElement("div");
+  box.className = "cfg-subsection";
+  const heading = document.createElement("h4");
+  heading.textContent = "Weather events";
+  box.appendChild(heading);
+
+  if (!anyEvents) {
+    const off = document.createElement("div");
+    off.className = "cfg-hint-block";
+    off.textContent = "No event tagging is switched on for this setup yet — see the Events "
+      + "section further down this page. This setting takes effect once it is.";
+    box.appendChild(off);
+  }
+
+  box.appendChild(fieldRow("Follow weather events",
+    `On: this camera speeds up to the burst interval while a ${tagList} tag is active, and gets `
+    + "its own event clip for each of those spans. Off: it ignores events entirely — it holds "
+    + "its normal capture interval through the storm and no event clips are built from its "
+    + "frames. Turn it off for a camera the weather isn't visible from — indoors, a doorway, a "
+    + "tight framing — where the extra frames are just disk and the clip is a video of nothing "
+    + "happening. Frames still get tagged either way, so the metadata stays complete.",
+    checkboxField(`cameras.${i}.events_enabled`, {default: true})));
 
   return box;
 }


### PR DESCRIPTION
A camera can now set `events_enabled: false` and ignore events entirely — no burst capture, **and** no event videos. For a camera the weather isn't visible from (indoors, a doorway, a tight framing) the burst frames are just disk and the event clip is a video of nothing happening.

```yaml
cameras:
  - name: front-door
    events_enabled: false     # default true; omit to participate normally
```

## What changed

- **`capture.py`** — `Conditions.interval()` now takes the camera's opt-out and returns its base interval instead of `burst_interval_seconds`, so the burst is resolved **per camera**. The loop already ticks at `min()` of the effective intervals and marks each camera due on its own clock-aligned slot, so an opted-out camera simply isn't due as often — the gating was already there.
- **`build_timelapse.py`** — `build_event_videos` skips opted-out cameras. Daily and yearly builds are untouched.
- **`common.py`** — `camera_events_enabled()`, alongside the existing per-camera resolvers.
- **`webapp/app.py`** — rejects a non-boolean `cameras[i].events_enabled`.
- **`webapp/static/index.html`** — a "Weather events" group per camera.

## Two decisions worth a look

**Frames are still tagged** on an opted-out camera. The JPEG comment is metadata for the search/filter features built on it, it costs nothing, and dropping it would leave a hole in the frame record — it's the capture *rate* and the video *build* that opt out, not the metadata. There's a comment at the tag site so this reads as a choice rather than an oversight.

**The checkbox got its own section** rather than going into "Capture schedule", because it isn't a schedule. Bonus: that section finds its show/hide toggle with `querySelector('input[type="checkbox"]')`, which takes the first checkbox in the box — a second one added there would have silently broken the daylight-window toggle.

## Verification

Drove the **real capture loop** on a simulated clock with a forced storm tag (`events.force_tags`), three cameras, burst 10s / base 60s:

| camera | `events_enabled` | frames in 180s | steady-state gap |
|---|---|---|---|
| front-yard | default (true) | 19 | 10s (burst) |
| wildlife | default (true) | 19 | 10s (burst) |
| front-door | **false** | 4 | **60s (held base)** |

Control run with no storm: 60s / 300s / 60s — per-camera intervals unchanged. The events build produced clips for `front-yard` and `wildlife` only, and `events.jsonl` matched.

Config page round-trip checked end to end: UI toggle → validator → `config.yaml` → `load_config` → `camera_events_enabled`, both directions, written as real YAML booleans.

Defaults to true, so existing configs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)