### PR TITLE
Forecast tab: upcoming storms, snow, and moon events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every push/PR to `main`).
 
 ### Added
+- **Forecast tab: upcoming storms, snow, and moon events.** The counterpart to
+  the backward-looking Events tab — the next 10 days of what's worth pointing a
+  camera at, so you can plan for a storm instead of finding out afterwards.
+  Storms are detected by applying the *same* CAPE/gust/precipitation thresholds
+  used for live tagging to forecast hours, so a forecast storm means what a
+  detected storm means; retuning the thresholds retunes both. The check runs per
+  hour rather than per day, since a day's peak instability and its heaviest rain
+  can be twelve hours apart and pairing them would invent storms no real hour
+  supports. Rather than invent a confidence score, the tab surfaces what the
+  forecasts actually said: probability of precipitation, whether Open-Meteo and
+  the NWS agree, and how far out the day is. NWS reaches ~7 days and Open-Meteo
+  10, so days 8-10 are marked single-source instead of looking as solid as
+  tomorrow. Moon events are computed rather than predicted, so they carry no
+  percentage and no uncertainty caveat. New `GET /api/forecast`, cached 30
+  minutes; a failed refresh keeps serving the last good forecast labelled with
+  its age, because an empty forecast built during an outage is indistinguishable
+  from a genuinely calm week. Degrades to moon-events-only with no location
+  configured, and works outside the US on Open-Meteo alone. Configurable via
+  `events.forecast_days` (1-10) and `events.forecast_snow_cm_min`.
 - **Per-camera capture schedules.** A camera can now set its own
   `daylight_window` (`enabled`/`mode`/`buffer_minutes`) and `interval_seconds`,
   each falling back to the global `capture` settings independently. This lets a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   minutes; a failed refresh keeps serving the last good forecast labelled with
   its age, because an empty forecast built during an outage is indistinguishable
   from a genuinely calm week. Degrades to moon-events-only with no location
-  configured, and works outside the US on Open-Meteo alone. Configurable via
+  configured, and works outside the US on Open-Meteo alone. Respects
+  `events.weather_enabled` and `events.lunar_enabled`, so a deployment with
+  weather tagging off makes no outbound weather calls when the tab is opened and
+  one with lunar tagging off never triggers the ephemeris download — the tab
+  explains what's switched off rather than just looking empty. Configurable via
   `events.forecast_days` (1-10) and `events.forecast_snow_cm_min`.
 - **Per-camera capture schedules.** A camera can now set its own
   `daylight_window` (`enabled`/`mode`/`buffer_minutes`) and `interval_seconds`,

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ through a bundled single-page web app.
 - **Lunar event detection.** Computes full/blue/harvest moons and lunar
   eclipses (blood moon = total) locally via Skyfield — no location or API
   needed.
+- **Upcoming-event forecast.** A Forecast tab looking 10 days ahead at storms,
+  snow, and moon events, so you know what's worth pointing a camera at before
+  it happens. Uses the same storm thresholds as live detection, and shows what
+  the forecasts actually say rather than inventing a confidence score.
 - **Season tagging.** Every frame and video is tagged with its astronomical
   season (spring/summer/fall/winter), hemisphere-aware — useful for filtering
   once a search UI exists, and it's what "changing seasons" is about anyway.
@@ -72,6 +76,9 @@ through a bundled single-page web app.
   secrets, which stay read-only and env-var-only. Includes network discovery
   to find Reolink cameras/NVRs on your LAN. See
   [Config page & network discovery](#config-page--network-discovery).
+- **Forecast dashboard.** A Forecast tab lists the next 10 days of expected
+  storms, snow, and moon events with the forecasts' own confidence signals.
+  See [Forecast tab](#forecast-tab-whats-coming).
 - **Storage dashboard.** A Storage tab shows per-camera and system-wide disk
   usage, growth rate, average build time, current retention settings, and a
   shortage/excess forecast — updated automatically after every nightly build.
@@ -609,6 +616,82 @@ check visibility against.
 Lunar tags are metadata only by default — they don't trigger burst capture.
 Add them to `events_video.tags` if you want an automatic clip, e.g.
 `2026-03-03_blood-moon.mp4`.
+
+## Forecast tab (what's coming)
+
+The Events tab is backward-looking: clips already cut from storms that
+happened. The **Forecast** tab is its counterpart — the next 10 days of
+storms, snow, and moon events, so you can plan around them.
+
+It is read-only. It never changes what gets captured, never triggers a burst,
+and writes nothing. It exists to answer "is anything worth watching for this
+week?"
+
+### It agrees with what actually gets tagged
+
+A forecast storm means exactly what a detected storm means, because it's the
+same test: the CAPE, gust, and precipitation thresholds under
+[How a storm is detected](#how-a-storm-is-detected) are applied to forecast
+hours instead of the current hour. Retune those thresholds and the Forecast
+tab retunes with them.
+
+The check runs per *hour*, not per day. Open-Meteo also publishes daily
+aggregates, but a day's peak instability and its heaviest rain can be twelve
+hours apart, and pairing them would invent storms that no actual hour
+supports.
+
+### Confidence, and why there's no confidence score
+
+Your day-8 storm is a maybe; tomorrow's is close to a fact. Rather than
+compress that into a number we made up, the tab shows the things the
+forecasts actually said:
+
+- **Probability of precipitation**, straight from the APIs.
+- **Whether the two sources agree.** Open-Meteo and the US National Weather
+  Service are independent forecasts. "Both forecasts agree" is meaningfully
+  stronger than "Open-Meteo only — the NWS forecast doesn't show it", and the
+  tab says which it is.
+- **How far out it is**, both in words ("in 3 days") and as the weight of the
+  stripe down the left edge of each day.
+
+NWS forecasts reach about 7 days; Open-Meteo reaches 10. Days 8-10 therefore
+rest on a single model, and the tab marks them rather than letting them look
+as solid as tomorrow. Outside the US, NWS has no data at all — Open-Meteo
+carries the whole forecast and every day is marked single-source.
+
+Moon events are handled differently on purpose. They're computed from an
+ephemeris, not predicted, so a full moon nine days out is exactly as certain
+as one tomorrow. They get no percentage, no probability bar, and no
+"treat this as a heads-up" caveat — just a solid chip and the note that it's
+calculated rather than forecast.
+
+### Degrading gracefully
+
+These are free services and they hand out 502s, 503s, and timeouts routinely.
+
+- The forecast is cached for 30 minutes, so browsing the UI doesn't hammer
+  them — a page load costs nothing.
+- If a refresh fails, the last good forecast keeps being served, labelled with
+  its age. This matters more than it sounds: a failed fetch produces a
+  perfectly well-formed forecast with *no storms in it*, which is
+  indistinguishable from a genuinely calm week. Serving that would quietly
+  tell you "nothing coming" when the truth is "we couldn't ask" — the same
+  trap `stale_grace_minutes` avoids for live capture.
+- With no location configured, weather is skipped and the tab still shows moon
+  events, with a note explaining what to set.
+
+### Settings
+
+Both live under `events:` in `config.yaml`, and both are editable from the
+Config page:
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `forecast_days` | `10` | How far ahead to look, 1-10. Set it to `7` to show only days both forecasts cover. |
+| `forecast_snow_cm_min` | `0.5` | Snow across a day before it's worth showing. A dusting that melts on contact makes a dull timelapse. |
+
+The storm thresholds are shared with live detection and documented under
+[How a storm is detected](#how-a-storm-is-detected).
 
 ## Season tagging
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -210,6 +210,19 @@ events:
                               # "all clear". Stops a blip ending a burst
                               # mid-storm. Default: 3 polls.
 
+  # The web UI's Forecast tab — upcoming storms, snow, and moon events. It is
+  # read-only and never affects capture. The same thresholds above decide what
+  # counts as a forecast storm, so what it predicts agrees with what actually
+  # gets tagged. Weather needs a location; moon events need none.
+  forecast_days: 10           # how far ahead the Forecast tab looks, 1-10.
+                              # Open-Meteo reaches 10 days; the NWS forecast
+                              # used to corroborate it only reaches about 7, so
+                              # days 8-10 rest on a single model and say so.
+  forecast_snow_cm_min: 0.5   # cm of snow across a day before it's worth
+                              # showing. A dusting that melts on contact makes
+                              # a dull timelapse; this is roughly "you can see
+                              # it settling".
+
 events_video:
   tags: [storm, snow]         # render a clip per active span of these tags
   min_frames: 30

--- a/forecast.py
+++ b/forecast.py
@@ -1,0 +1,587 @@
+"""Forward-looking counterpart to events.py: what's worth filming in the next
+week or so.
+
+events.py answers "is something happening *right now*?" — it drives frame
+tagging and burst capture. This module answers "is something coming?" and
+feeds the web UI's Forecast tab. Nothing here touches capture; it is a
+read-only view.
+
+Two kinds of prediction live side by side, and the difference matters:
+
+- Weather is *probabilistic*. A storm eight days out is a hint; the same storm
+  tomorrow is close to a fact. We never invent a confidence score to express
+  that. Instead we report what the APIs actually say — the forecast
+  probability of precipitation, and whether the two independent sources agree —
+  and let the UI render the uncertainty from those facts.
+- Moon events are *deterministic*. Skyfield computes them from an ephemeris,
+  so a full moon nine days out is exactly as certain as one tomorrow. They
+  carry no probability and must not be drawn as if they had one.
+
+Sources are the same ones events.py already uses, so a forecast storm means
+the same thing a detected storm does — the thresholds are literally the same
+constants (see `events.STORM_CAPE_MIN` and friends):
+
+- Open-Meteo hourly forecast, 10 days. CAPE *is* available on the forecast
+  endpoint (unlike the archive endpoint, where it is not), which is what lets
+  us apply the identical CAPE+precipitation test to a future hour.
+- NWS gridpoint forecast (US only), which reaches about 7 days. Used purely to
+  corroborate: it is the second opinion, never the sole trigger.
+"""
+
+import datetime as dt
+import logging
+import threading
+import time
+
+import requests
+
+import events
+from common import tzinfo_for
+from events import USER_AGENT, WMO_TAGS, _num
+
+log = logging.getLogger("forecast")
+
+# Open-Meteo serves 10 days of hourly data (verified: 240 hours, CAPE
+# non-null throughout). NWS gridpoint forecasts run to roughly 7 days, so
+# days beyond this are single-source and the UI says so.
+MAX_FORECAST_DAYS = 10
+DEFAULT_FORECAST_DAYS = 10
+
+# Snowfall worth pointing a camera at, in cm for the whole local day. A dusting
+# that melts on contact makes a dull timelapse; this is roughly "you can see it
+# settling". Override with `events.forecast_snow_cm_min`.
+SNOW_MIN_CM = 0.5
+
+# The forecast updates hourly at most, and these are free services being asked
+# nicely — so the browser hitting /api/forecast on every page load must not
+# become a request to Open-Meteo on every page load.
+CACHE_TTL_SECONDS = 30 * 60
+
+# How long a cached payload keeps being served after a refresh *fails*. Free
+# weather APIs hand out 502/503s and timeouts regularly (the same reality that
+# motivated events.stale_grace_minutes), and a six-hour-old forecast is far
+# more useful than an error card. Anything staler than this is dropped and the
+# UI is told the forecast is unavailable rather than shown something wrong.
+STALE_MAX_SECONDS = 12 * 3600
+
+# {cache key: (fetched_at, payload)} guarded by _CACHE_LOCK — the Flask app is
+# threaded, so two simultaneous page loads must not both hit the network.
+_CACHE = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def _clear_cache():
+    """Drop cached forecasts (used by tests)."""
+    with _CACHE_LOCK:
+        _CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Open-Meteo
+# ---------------------------------------------------------------------------
+
+def _thresholds(events_cfg):
+    """Storm thresholds, config-overridable — the same values, read the same
+    way, that events.open_meteo_tags uses for current conditions. Keeping this
+    in one expression is the point: if a storm is worth a burst capture now, an
+    identical forecast hour is worth flagging on the calendar."""
+    return (
+        _num(events_cfg.get("storm_cape_min"), events.STORM_CAPE_MIN),
+        _num(events_cfg.get("storm_gust_kmh"), events.STORM_GUST_MIN),
+        _num(events_cfg.get("storm_precip_mm"), events.STORM_PRECIP_MIN),
+    )
+
+
+def fetch_open_meteo(lat, lon, days, timeout=15):
+    """Hourly forecast for `days` days, timestamps already in local time.
+
+    Hourly rather than daily on purpose. The daily endpoint gives
+    precipitation_sum and wind_gusts_10m_max, but those are whole-day
+    aggregates — pairing a calm morning's peak CAPE with an unrelated evening
+    shower would invent storms that no single hour supports. CAPE is also only
+    offered hourly. Requiring the thresholds to be met *within one hour* is
+    what makes this the same test events.py applies to one instant of now.
+    """
+    resp = requests.get(
+        "https://api.open-meteo.com/v1/forecast",
+        params={
+            "latitude": lat,
+            "longitude": lon,
+            "hourly": "weather_code,precipitation,precipitation_probability,"
+                      "snowfall,wind_gusts_10m,cape",
+            "forecast_days": days,
+            "timezone": "auto",
+        },
+        headers={"User-Agent": USER_AGENT},
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _open_meteo_days(payload, events_cfg, now=None):
+    """Open-Meteo hourly payload -> {local date: {...day summary...}}.
+
+    `now` is the current local time at the forecast location. Hours before it
+    are dropped: Open-Meteo's first day starts at 00:00, so without this a
+    storm that already blew through at 3 AM would be listed as upcoming, and
+    by late evening today would still be advertising this morning's weather.
+    """
+    cape_min, gust_min, precip_min = _thresholds(events_cfg)
+    snow_min = _num(events_cfg.get("forecast_snow_cm_min"), SNOW_MIN_CM)
+
+    hourly = payload.get("hourly") or {}
+    times = hourly.get("time") or []
+
+    def series(name):
+        # A field the model doesn't provide comes back null (or missing
+        # entirely). Treat it as absent, never as a calm zero.
+        return hourly.get(name) or [None] * len(times)
+
+    codes = series("weather_code")
+    precip = series("precipitation")
+    pops = series("precipitation_probability")
+    snowfall = series("snowfall")
+    gusts = series("wind_gusts_10m")
+    capes = series("cape")
+
+    days = {}
+    for i, stamp in enumerate(times):
+        try:
+            when = dt.datetime.fromisoformat(stamp)
+        except (TypeError, ValueError):
+            continue
+        if now is not None and when < now:
+            continue        # already happened — this is a forecast, not a log
+        day = days.setdefault(when.date(), {
+            "storm_hours": [], "storm_reasons": [], "storm_pops": [],
+            "snow_cm": 0.0, "snow_hours": [], "snow_pops": [],
+            "peak_cape": 0.0, "peak_gust": 0.0,
+        })
+
+        code = codes[i]
+        hour_precip = _num(precip[i], 0.0)
+        hour_gust = _num(gusts[i], 0.0)
+        hour_cape = _num(capes[i], 0.0)
+        hour_snow = _num(snowfall[i], 0.0)
+        pop = pops[i]
+
+        day["peak_cape"] = max(day["peak_cape"], hour_cape)
+        day["peak_gust"] = max(day["peak_gust"], hour_gust)
+        day["snow_cm"] += hour_snow
+
+        storm = False
+        if code in WMO_TAGS["storm"]:
+            storm = True
+            day["storm_reasons"].append(f"thunderstorm in the forecast (WMO {code})")
+        # Rain actually falling, with the instability to drive convection.
+        # CAPE alone is only potential — it sits high under clear skies — so
+        # exactly as in events.py it never qualifies on its own.
+        if hour_precip >= precip_min and hour_cape >= cape_min:
+            storm = True
+            day["storm_reasons"].append(
+                f"{hour_cape:.0f} J/kg CAPE with {hour_precip:.1f} mm rain")
+        # A gust front is worth filming wet or dry.
+        if hour_gust >= gust_min:
+            storm = True
+            day["storm_reasons"].append(f"{hour_gust:.0f} km/h gusts")
+
+        if storm:
+            day["storm_hours"].append(when)
+            if pop is not None:
+                day["storm_pops"].append(int(pop))
+
+        if hour_snow > 0 or code in WMO_TAGS["snow"]:
+            day["snow_hours"].append(when)
+            if pop is not None:
+                day["snow_pops"].append(int(pop))
+
+    # Trailing pass: a day only counts as snowy if enough actually accumulates.
+    for day in days.values():
+        if day["snow_cm"] < snow_min:
+            day["snow_hours"] = []
+            day["snow_pops"] = []
+    return days
+
+
+# ---------------------------------------------------------------------------
+# NWS (US only) — corroboration, never the sole trigger
+# ---------------------------------------------------------------------------
+
+def _nws_forecast_url(lat, lon, timeout=10):
+    """The gridpoint forecast URL for a location, cached in events._NET_CACHE
+    alongside the observation-station lookup — the grid a point falls in never
+    moves, so this is one request per location per process."""
+    key = ("forecast_url", round(lat, 3), round(lon, 3))
+    if key in events._NET_CACHE:
+        return events._NET_CACHE[key]
+    resp = requests.get(
+        f"https://api.weather.gov/points/{lat},{lon}",
+        headers={"User-Agent": USER_AGENT, "Accept": "application/geo+json"},
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    url = (resp.json().get("properties") or {}).get("forecast")
+    if not url:
+        raise RuntimeError("NWS returned no forecast URL for this point")
+    events._NET_CACHE[key] = url
+    return url
+
+
+def fetch_nws(lat, lon, timeout=15):
+    """NWS day/night forecast periods, or None outside the US.
+
+    api.weather.gov answers 404 for any point it has no data for — every
+    non-US location, which is expected rather than a fault. Returning None
+    lets the caller say "one source here" instead of "something broke".
+    """
+    try:
+        url = _nws_forecast_url(lat, lon, timeout)
+    except requests.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            log.debug("NWS has no data for %.3f, %.3f (non-US?)", lat, lon)
+            return None
+        raise
+    resp = requests.get(
+        url, headers={"User-Agent": USER_AGENT, "Accept": "application/geo+json"},
+        timeout=timeout)
+    resp.raise_for_status()
+    return (resp.json().get("properties") or {}).get("periods") or []
+
+
+def _nws_days(periods):
+    """NWS periods -> {local date: {tag: {"pop": int|None, "text": str}}}.
+
+    Periods are day/night halves, not days, so two can land on one date; we
+    keep the wettest reading for each tag.
+    """
+    days = {}
+    for period in periods or []:
+        start = period.get("startTime")
+        if not start:
+            continue
+        try:
+            date = dt.datetime.fromisoformat(start).date()
+        except ValueError:
+            continue
+        text = str(period.get("shortForecast") or "")
+        pop = (period.get("probabilityOfPrecipitation") or {}).get("value")
+        pop = int(pop) if pop is not None else None
+        lowered = text.lower()
+        for substring, tag in events.NWS_TAG_MAP:
+            if tag not in ("storm", "snow") or substring not in lowered:
+                continue
+            entry = days.setdefault(date, {}).setdefault(tag, {"pop": None, "text": text})
+            if pop is not None and (entry["pop"] is None or pop > entry["pop"]):
+                entry["pop"] = pop
+                entry["text"] = text
+    return days
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+def _window_label(hours):
+    """['2026-08-10T14:00', ...] -> "2 PM – 7 PM" for the UI."""
+    if not hours:
+        return None
+
+    def fmt(when):
+        hour = when.hour % 12 or 12
+        return f"{hour} {'AM' if when.hour < 12 else 'PM'}"
+
+    first, last = min(hours), max(hours)
+    if first.hour == last.hour:
+        return fmt(first)
+    return f"{fmt(first)} – {fmt(last)}"
+
+
+def _weather_event(kind, om_day, nws_entry, nws_covers_day):
+    """One weather event for a day, or None if neither source flags it.
+
+    `agreement` is a statement of fact about the sources — not a score we made
+    up. The UI turns it into visual weight; this function never does.
+    """
+    om_hours = om_day["storm_hours"] if kind == "storm" else om_day["snow_hours"]
+    om_hit = bool(om_hours)
+    nws_hit = nws_entry is not None
+    if not om_hit and not nws_hit:
+        return None
+
+    sources = ([{"name": "open-meteo"}] if om_hit else []) + \
+              ([{"name": "nws"}] if nws_hit else [])
+    if not nws_covers_day:
+        agreement = "single-source"       # NWS has no data this far out / not US
+    elif om_hit and nws_hit:
+        agreement = "both"
+    elif om_hit:
+        agreement = "open-meteo-only"
+    else:
+        agreement = "nws-only"
+
+    om_pops = om_day["storm_pops"] if kind == "storm" else om_day["snow_pops"]
+    pops = list(om_pops)
+    if nws_entry and nws_entry.get("pop") is not None:
+        pops.append(nws_entry["pop"])
+
+    if kind == "storm":
+        reasons = list(dict.fromkeys(om_day["storm_reasons"]))[:3]
+        detail = "; ".join(reasons)
+        headline = "Thunderstorms"
+    else:
+        detail = f"{om_day['snow_cm']:.1f} cm expected" if om_day["snow_cm"] else ""
+        headline = "Snow"
+    if nws_entry:
+        nws_text = nws_entry["text"]
+        detail = f"{detail} · NWS: {nws_text}" if detail else f"NWS: {nws_text}"
+
+    return {
+        "kind": kind,
+        "certain": False,
+        "headline": headline,
+        "detail": detail,
+        # The APIs' own number, not ours. None when neither source gave one.
+        "probability": max(pops) if pops else None,
+        "agreement": agreement,
+        "sources": [s["name"] for s in sources],
+        "window": _window_label(om_hours),
+        # Only meaningful when Open-Meteo is what flagged the day — quoting a
+        # peak CAPE next to an NWS-only entry would imply Open-Meteo agreed.
+        "peak_cape": round(om_day["peak_cape"]) if (kind == "storm" and om_hit) else None,
+        "peak_gust": round(om_day["peak_gust"]) if (kind == "storm" and om_hit) else None,
+    }
+
+
+# Moon tags that are worth planning a shoot around, in the order we'd rank
+# them. events.moon_tags returns the reason text already written for humans.
+MOON_PRIORITY = ["blood-moon", "lunar-eclipse", "blue-moon", "harvest-moon", "full-moon"]
+
+
+def _moon_events(date, cache_dir, lat, lon):
+    """Deterministic lunar events for one future date.
+
+    Reuses events.moon_tags unchanged — it takes an arbitrary date and is pure
+    Skyfield arithmetic, so "what is the moon doing on day 9" costs nothing
+    extra and is exact.
+    """
+    try:
+        tags = events.moon_tags(date, cache_dir, lat, lon)
+    except Exception as exc:
+        log.warning("moon events for %s failed: %s", date, exc)
+        return []
+    out = []
+    for tag in MOON_PRIORITY:
+        if tag in tags:
+            out.append({
+                "kind": tag,
+                "certain": True,          # computed, not predicted
+                "headline": tags[tag][:1].upper() + tags[tag][1:],
+                "detail": "",
+                "probability": None,
+                "agreement": None,
+                "sources": ["skyfield"],
+                "window": None,
+            })
+    return out
+
+
+def _next_full_moon_beyond(last_date, cache_dir):
+    """The first full moon after the forecast window, so a window with no moon
+    event still tells you when the next one is instead of showing nothing."""
+    try:
+        candidates = events.full_moon_dates(last_date.year, cache_dir)
+        candidates += events.full_moon_dates(last_date.year + 1, cache_dir)
+    except Exception as exc:
+        log.warning("next full moon lookup failed: %s", exc)
+        return None
+    for date in sorted(candidates):
+        if date > last_date:
+            return {"date": date.isoformat(), "days_away": (date - last_date).days}
+    return None
+
+
+def build_forecast(cfg, cache_dir, days=DEFAULT_FORECAST_DAYS):
+    """Assemble the upcoming-events payload. Never raises for a source
+    failure — a dead API becomes an entry in `sources` and a warning, so the
+    tab degrades to "moon events only" rather than to an error page."""
+    days = max(1, min(int(days), MAX_FORECAST_DAYS))
+    events_cfg = cfg.get("events") or {}
+    warnings = []
+    sources = {}
+
+    lat = lon = None
+    if events.has_location_configured(events_cfg):
+        try:
+            lat, lon = events.resolve_location(events_cfg)
+        except Exception as exc:
+            warnings.append(f"Could not resolve the configured location: {exc}. "
+                            "Weather forecasting is unavailable; moon events are "
+                            "unaffected.")
+    else:
+        warnings.append(
+            "No location is set, so storms and snow can't be forecast — add "
+            "events.zip or events.latitude/longitude on the Config page. Moon "
+            "events need no location and are shown below.")
+
+    om_days, nws_by_date, nws_covered = {}, {}, set()
+    tzname = None
+
+    if lat is not None:
+        try:
+            payload = fetch_open_meteo(lat, lon, days)
+            tzname = payload.get("timezone")
+            # Open-Meteo's hourly timestamps are naive local time for the
+            # location (timezone=auto), so "now" must be naive local time in
+            # that same zone to compare against them — a host in another zone
+            # would otherwise drop or keep the wrong hours.
+            local_now = dt.datetime.now(tzinfo_for(tzname)).replace(tzinfo=None)
+            om_days = _open_meteo_days(payload, events_cfg, now=local_now)
+            sources["open-meteo"] = {"ok": True}
+        except Exception as exc:
+            log.warning("Open-Meteo forecast failed: %s", exc)
+            sources["open-meteo"] = {"ok": False, "error": str(exc)}
+            warnings.append(f"Open-Meteo is not responding ({exc}). Storm and "
+                            "snow forecasts are missing or incomplete.")
+        try:
+            periods = fetch_nws(lat, lon)
+            if periods is None:
+                sources["nws"] = {"ok": True, "available": False,
+                                  "note": "NWS covers US locations only"}
+            else:
+                nws_by_date = _nws_days(periods)
+                nws_covered = {dt.datetime.fromisoformat(p["startTime"]).date()
+                               for p in periods if p.get("startTime")}
+                sources["nws"] = {"ok": True, "available": True}
+        except Exception as exc:
+            log.warning("NWS forecast failed: %s", exc)
+            sources["nws"] = {"ok": False, "available": False, "error": str(exc)}
+
+    # The calendar the *cameras* are on. A host clock in another zone must not
+    # shift the forecast a day relative to the days the Events tab shows.
+    # Resolved once — resolve_timezone can itself hit the network.
+    zone = tzname or events.resolve_timezone(cfg)
+    today = dt.datetime.now(tzinfo_for(zone)).date()
+    out_days = []
+    for offset in range(days):
+        date = today + dt.timedelta(days=offset)
+        day_events = []
+
+        om_day = om_days.get(date)
+        if om_day:
+            nws_day = nws_by_date.get(date) or {}
+            covers = date in nws_covered
+            for kind in ("storm", "snow"):
+                event = _weather_event(kind, om_day, nws_day.get(kind), covers)
+                if event:
+                    day_events.append(event)
+
+        if bool(events_cfg.get("lunar_enabled", True)):
+            day_events += _moon_events(date, cache_dir, lat, lon)
+
+        out_days.append({
+            "date": date.isoformat(),
+            "lead_days": offset,
+            # Days past NWS's ~7-day reach have only one model behind them.
+            # Surfaced as a fact so the UI can mark them without guessing.
+            "nws_covered": date in nws_covered,
+            "events": day_events,
+        })
+
+    last_date = today + dt.timedelta(days=days - 1)
+    return {
+        "generated_at": dt.datetime.now().astimezone().isoformat(timespec="seconds"),
+        "timezone": zone,
+        "days": out_days,
+        "sources": sources,
+        "warnings": warnings,
+        "has_location": lat is not None,
+        "next_full_moon": _next_full_moon_beyond(last_date, cache_dir),
+        "stale": False,
+    }
+
+
+def _weather_usable(payload) -> bool:
+    """Did we actually get a weather forecast, as opposed to an empty one?
+
+    This is the distinction that matters for caching. build_forecast never
+    raises on a source failure — it returns a well-formed payload with no
+    storms in it. That shape is indistinguishable from a genuinely calm ten
+    days, so caching or displaying it during an Open-Meteo outage would quietly
+    tell you "nothing coming" when the truth is "we couldn't ask". Same reason
+    capture.py holds a source's last good tags instead of reading a timeout as
+    all-clear.
+
+    A location-less config has no weather to fetch and nothing to be stale
+    about, so it counts as usable.
+    """
+    if not payload.get("has_location"):
+        return True
+    return bool((payload.get("sources", {}).get("open-meteo") or {}).get("ok"))
+
+
+def get_forecast(cfg, cache_dir, days=DEFAULT_FORECAST_DAYS, force=False):
+    """Cached build_forecast.
+
+    Two things this protects against, both of which the free weather APIs make
+    routine: hammering them on every page load, and letting a 502 masquerade as
+    good news. A refresh that comes back without weather is discarded in favour
+    of the last good payload, flagged `stale` so the UI can say how old it is.
+    """
+    ecfg = cfg.get("events") or {}
+    key = (round(_num(ecfg.get("latitude"), 0.0), 3),
+           round(_num(ecfg.get("longitude"), 0.0), 3),
+           str(ecfg.get("zip") or ecfg.get("zip_code") or ""), int(days))
+    now = time.time()
+
+    with _CACHE_LOCK:
+        cached = _CACHE.get(key)
+    if cached and not force and now - cached[0] < CACHE_TTL_SECONDS:
+        return cached[1]
+
+    def serve_stale():
+        """Last good payload, aged and labelled — or None if there isn't one."""
+        if not cached or now - cached[0] >= STALE_MAX_SECONDS:
+            return None
+        stale = dict(cached[1])
+        stale["stale"] = True
+        stale["stale_minutes"] = int((now - cached[0]) / 60)
+        return stale
+
+    try:
+        payload = build_forecast(cfg, cache_dir, days)
+    except Exception as exc:
+        log.warning("forecast build failed: %s", exc)
+        fallback = serve_stale()
+        if fallback is None:
+            raise
+        return fallback
+
+    if not _weather_usable(payload):
+        # Don't cache it either — a 30-minute TTL on an all-clear built during
+        # an outage would outlive the outage itself.
+        fallback = serve_stale()
+        if fallback is not None:
+            log.info("weather sources down; serving forecast from %s minutes ago",
+                     fallback["stale_minutes"])
+            return fallback
+
+    with _CACHE_LOCK:
+        _CACHE[key] = (now, payload)
+    return payload
+
+
+if __name__ == "__main__":
+    # Quick check against the real APIs:
+    #   forecast.py <lat> <lon> [days]
+    import json
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+    args = sys.argv[1:]
+    if len(args) < 2:
+        sys.exit("usage: forecast.py <lat> <lon> [days]")
+    cfg = {"events": {"latitude": float(args[0]), "longitude": float(args[1]),
+                      "lunar_enabled": True}}
+    n = int(args[2]) if len(args) > 2 else DEFAULT_FORECAST_DAYS
+    print(json.dumps(build_forecast(cfg, events.APP_ROOT / ".ephemeris", n), indent=2))

--- a/forecast.py
+++ b/forecast.py
@@ -410,8 +410,20 @@ def build_forecast(cfg, cache_dir, days=DEFAULT_FORECAST_DAYS):
     warnings = []
     sources = {}
 
+    # Honour the same two switches capture does (see events.get_active_tags).
+    # Forecasting is a different feature from tagging, but the flags mean "do
+    # not go and fetch this" — weather_enabled: false must not still send the
+    # user's coordinates to Open-Meteo and NWS whenever someone opens the tab,
+    # and lunar_enabled: false must not trigger the ~17 MB ephemeris download.
+    weather_on = bool(events_cfg.get("weather_enabled"))
+    lunar_on = bool(events_cfg.get("lunar_enabled"))
+
     lat = lon = None
-    if events.has_location_configured(events_cfg):
+    if not weather_on:
+        warnings.append(
+            "Weather tagging is off, so storms and snow aren't forecast — turn on "
+            "\"Storm/snow/rain tagging\" on the Config page to see them here.")
+    elif events.has_location_configured(events_cfg):
         try:
             lat, lon = events.resolve_location(events_cfg)
         except Exception as exc:
@@ -476,7 +488,7 @@ def build_forecast(cfg, cache_dir, days=DEFAULT_FORECAST_DAYS):
                 if event:
                     day_events.append(event)
 
-        if bool(events_cfg.get("lunar_enabled", True)):
+        if lunar_on:
             day_events += _moon_events(date, cache_dir, lat, lon)
 
         out_days.append({
@@ -496,7 +508,7 @@ def build_forecast(cfg, cache_dir, days=DEFAULT_FORECAST_DAYS):
         "sources": sources,
         "warnings": warnings,
         "has_location": lat is not None,
-        "next_full_moon": _next_full_moon_beyond(last_date, cache_dir),
+        "next_full_moon": _next_full_moon_beyond(last_date, cache_dir) if lunar_on else None,
         "stale": False,
     }
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -58,6 +58,9 @@ REQUIRED_SECTIONS = ("capture", "storage", "daily_video", "yearly")
 # Keep in sync with capture.py's MIN_INTERVAL_SECONDS — the floor on poll rate.
 MIN_INTERVAL_SECONDS = 10
 
+# Keep in sync with forecast.py's MAX_FORECAST_DAYS — Open-Meteo's ceiling.
+MAX_FORECAST_DAYS = 10
+
 # --- Config-page authentication --------------------------------------------
 # A single optional passcode (no username) gates the Config page and its
 # write/scan endpoints. It's opt-in: with no passcode set, everything behaves
@@ -210,7 +213,8 @@ def validate_config(cfg):
     # Storm-detection thresholds: any non-negative number. A bad value here
     # would otherwise fail open (fall back to the default) and quietly not do
     # what the user asked.
-    for key in ("storm_cape_min", "storm_precip_mm", "storm_gust_kmh", "stale_grace_minutes"):
+    for key in ("storm_cape_min", "storm_precip_mm", "storm_gust_kmh",
+                "stale_grace_minutes", "forecast_snow_cm_min"):
         val = (cfg.get("events") or {}).get(key)
         if val is None:
             continue
@@ -218,6 +222,16 @@ def validate_config(cfg):
             problems.append(f"events.{key} must be a number")
         elif val < 0:
             problems.append(f"events.{key} must not be negative")
+
+    # The Forecast tab's window. Open-Meteo serves 10 days and no more, so a
+    # larger number would silently be clamped rather than do what was asked.
+    days = (cfg.get("events") or {}).get("forecast_days")
+    if days is not None:
+        if isinstance(days, bool) or not isinstance(days, int):
+            problems.append("events.forecast_days must be a whole number")
+        elif not 1 <= days <= MAX_FORECAST_DAYS:
+            problems.append(f"events.forecast_days must be between 1 and {MAX_FORECAST_DAYS} "
+                            "(the forecast APIs don't reach further out)")
 
     # Minimum poll interval — faster than this risks overloading the camera/NVR.
     for path, val in (("capture.interval_seconds", (cfg.get("capture") or {}).get("interval_seconds")),
@@ -477,6 +491,31 @@ def create_app(cfg, config_path=None):
         # Polled by the UI to show a "building videos…" indicator. Cheap: reads
         # one small JSON file the build process writes.
         return jsonify(read_build_status(state["cfg"]))
+
+    @app.get("/api/forecast")
+    def forecast_upcoming():
+        """Upcoming storm/snow/moon events for the Forecast tab.
+
+        Cached in forecast.py (30 min), so a page load costs nothing and the
+        free weather APIs aren't hammered. Degrades rather than fails: no
+        location or a dead API still returns 200 with the moon events and a
+        warning, because a half-forecast is worth showing.
+        """
+        import forecast as forecast_mod
+        cfg = state["cfg"]
+        configured = (cfg.get("events") or {}).get("forecast_days")
+        try:
+            days = int(request.args.get(
+                "days", configured or forecast_mod.DEFAULT_FORECAST_DAYS))
+        except (TypeError, ValueError):
+            days = forecast_mod.DEFAULT_FORECAST_DAYS
+        cache_dir = Path(cfg["storage"]["root"]) / "ephemeris"
+        try:
+            return jsonify(forecast_mod.get_forecast(cfg, cache_dir, days))
+        except Exception as exc:
+            # Only reached when there's nothing cached to fall back on either.
+            return jsonify({"error": f"forecast unavailable: {exc}", "days": [],
+                            "warnings": [], "sources": {}}), 503
 
     @app.get("/api/storage")
     def storage():

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -307,6 +307,103 @@
     font-size: var(--fs-xs);
   }
 
+  /* --- Forecast tab -------------------------------------------------- */
+  #forecast-view { width: 100%; max-width: 760px; }
+  .fc-head { margin-bottom: var(--space-4); }
+  .fc-title { font-size: var(--fs-lg); font-weight: var(--fw-semibold); }
+  .fc-sub { color: var(--text-2); font-size: var(--fs-sm); margin-top: var(--space-1); }
+  .fc-note {
+    margin-bottom: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-sm);
+    background: var(--accent-quiet);
+    color: var(--accent);
+    font-size: var(--fs-sm);
+  }
+  .fc-days { display: flex; flex-direction: column; gap: var(--space-2); }
+
+  .fc-day {
+    background: var(--surface-1);
+    border: 1px solid var(--border);
+    /* Lead time is encoded on this edge — see .lead-* below. */
+    border-left-width: 3px;
+    border-radius: var(--radius-md);
+  }
+  .fc-day > summary {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    cursor: pointer;
+    list-style: none;
+  }
+  .fc-day > summary::-webkit-details-marker { display: none; }
+  .fc-day > summary:hover { background: var(--surface-2); border-radius: var(--radius-md); }
+  .fc-day[open] > summary { border-radius: var(--radius-md) var(--radius-md) 0 0; }
+  .fc-day.quiet {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-4);
+    background: none;
+    color: var(--text-3);
+  }
+  .fc-date { min-width: 108px; font-size: var(--fs-sm); font-weight: var(--fw-medium); }
+  .fc-date b { color: var(--text-1); }
+  .fc-day.quiet .fc-date { font-weight: var(--fw-regular); }
+  .fc-when { min-width: 76px; color: var(--text-3); font-size: var(--fs-xs); }
+  .fc-nothing { color: var(--text-3); font-size: var(--fs-xs); }
+  .fc-chips { display: flex; flex-wrap: wrap; gap: var(--space-2); flex: 1; }
+
+  /* Confidence is carried by this border: near days read solid, far days
+     faint. Deliberately the ONLY invented signal — everything numeric on the
+     card comes straight from the forecast APIs. */
+  .fc-day.lead-near { border-left-color: var(--accent); }
+  .fc-day.lead-mid  { border-left-color: var(--border-strong); }
+  .fc-day.lead-far  { border-left-color: var(--border); }
+
+  .fc-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 3px var(--space-3);
+    border-radius: var(--radius-pill);
+    font-size: var(--fs-xs);
+    border: 1px solid var(--border-strong);
+    white-space: nowrap;
+  }
+  .fc-chip .pct { font-weight: var(--fw-semibold); font-variant-numeric: tabular-nums; }
+  .fc-chip-storm { border-color: #e5a34b; color: #f0b86a; background: rgba(229, 163, 75, 0.12); }
+  .fc-chip-snow  { border-color: #7fb6e8; color: #9ccbf2; background: rgba(127, 182, 232, 0.12); }
+  /* Moon events are computed, not predicted — a filled chip with no
+     percentage, so they never read as "probably". */
+  .fc-chip-moon {
+    border-color: #c9cdd4; color: var(--surface-0);
+    background: #c9cdd4; font-weight: var(--fw-medium);
+  }
+
+  .fc-body {
+    padding: 0 var(--space-4) var(--space-3) var(--space-4);
+    border-top: 1px solid var(--border);
+    padding-top: var(--space-3);
+  }
+  .fc-event { font-size: var(--fs-sm); margin-bottom: var(--space-3); }
+  .fc-event:last-child { margin-bottom: 0; }
+  .fc-event-head { font-weight: var(--fw-medium); margin-bottom: var(--space-1); }
+  .fc-event-line { color: var(--text-2); font-size: var(--fs-xs); }
+  .fc-meter {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--surface-2);
+    margin: var(--space-2) 0;
+    max-width: 240px;
+    overflow: hidden;
+  }
+  .fc-meter > span { display: block; height: 100%; background: var(--accent); }
+  .fc-agree { color: var(--text-2); font-size: var(--fs-xs); }
+  .fc-certain { color: #c9cdd4; font-size: var(--fs-xs); }
+  .fc-footnote { margin-top: var(--space-4); color: var(--text-3); font-size: var(--fs-xs); }
+
   #cfg-view { width: 100%; max-width: 720px; }
   .cfg-section {
     background: var(--surface-1);
@@ -457,6 +554,14 @@
       order: 2;
     }
     #content-col { order: 1; }
+
+    /* The forecast summary row is date + relative day + chips, which needs
+       more than a phone's width. Let it wrap onto a second line and drop the
+       alignment columns, rather than overflow the card. */
+    .fc-day > summary, .fc-day.quiet { flex-wrap: wrap; }
+    .fc-date { min-width: 0; }
+    .fc-when { min-width: 0; }
+    .fc-chips { flex-basis: 100%; }
   }
 </style>
 </head>
@@ -472,6 +577,7 @@
     <button class="pill active" data-type="daily">Daily</button>
     <button class="pill" data-type="yearly">Yearly</button>
     <button class="pill" data-type="events">Events</button>
+    <button class="pill" data-type="forecast">Forecast</button>
     <button class="pill" data-type="storage">Storage</button>
     <button class="pill" data-type="config">Config</button>
   </div>
@@ -531,6 +637,7 @@ function refresh() {
     document.getElementById("cfg-footer").classList.remove("visible");
   }
   if (state.type === "storage") renderStorage();
+  else if (state.type === "forecast") renderForecast();
   else if (state.type === "config") renderConfig();
   else renderList();
 }
@@ -645,6 +752,206 @@ function play(v, itemEl) {
 
 function fmtGB(n) {
   return n >= 1 ? n.toFixed(2) + " GB" : Math.round(n * 1024) + " MB";
+}
+
+// --- Forecast tab ----------------------------------------------------------
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const FC_LABELS = {
+  storm: "Thunderstorms", snow: "Snow",
+  "full-moon": "Full moon", "blue-moon": "Blue moon",
+  "harvest-moon": "Harvest moon", "blood-moon": "Blood moon",
+  "lunar-eclipse": "Lunar eclipse",
+};
+
+// How each `agreement` value reads in plain English. These describe what the
+// sources actually said — we deliberately don't collapse them into an invented
+// "confidence: 73%" score, because that number would be ours, not the
+// forecast's. Lead time is shown separately and speaks for itself.
+const FC_AGREEMENT = {
+  both: "Both forecasts agree",
+  "open-meteo-only": "Open-Meteo only — the NWS forecast doesn't show it",
+  "nws-only": "NWS only — Open-Meteo doesn't show it",
+  "single-source": "One forecast only — beyond the NWS 7-day range",
+};
+
+function fcIsMoon(kind) { return kind !== "storm" && kind !== "snow"; }
+
+function fcChip(ev) {
+  const kindClass = ev.kind === "storm" ? "storm" : ev.kind === "snow" ? "snow" : "moon";
+  const span = document.createElement("span");
+  span.className = `fc-chip fc-chip-${kindClass}`;
+  const label = FC_LABELS[ev.kind] || ev.kind;
+  // Moon events carry no percentage on purpose — they're computed, not
+  // predicted, so a probability would be a lie.
+  span.innerHTML = ev.probability != null && !ev.certain
+    ? `${label} <span class="pct">${ev.probability}%</span>`
+    : label;
+  return span;
+}
+
+function fcDayLabel(iso, leadDays) {
+  // Parse as a plain local date — new Date("2026-08-09") would be parsed as
+  // UTC midnight and can render as the previous day west of Greenwich.
+  const [y, m, d] = iso.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  const when = leadDays === 0 ? "today" : leadDays === 1 ? "tomorrow" : `in ${leadDays} days`;
+  return {
+    label: `<b>${DAY_NAMES[date.getDay()]}</b> ${MONTH_NAMES[m - 1]} ${d}`,
+    when,
+  };
+}
+
+function fcEventDetail(ev) {
+  const wrap = document.createElement("div");
+  wrap.className = "fc-event";
+
+  const head = document.createElement("div");
+  head.className = "fc-event-head";
+  head.textContent = ev.headline || FC_LABELS[ev.kind] || ev.kind;
+  wrap.appendChild(head);
+
+  if (ev.certain) {
+    const line = document.createElement("div");
+    line.className = "fc-certain";
+    line.textContent = "Certain — calculated from orbital mechanics, not forecast";
+    wrap.appendChild(line);
+    return wrap;
+  }
+
+  if (ev.window) {
+    const line = document.createElement("div");
+    line.className = "fc-event-line";
+    line.textContent = `Expected around ${ev.window}`;
+    wrap.appendChild(line);
+  }
+  if (ev.detail) {
+    const line = document.createElement("div");
+    line.className = "fc-event-line";
+    line.textContent = ev.detail;
+    wrap.appendChild(line);
+  }
+  if (ev.peak_cape) {
+    const line = document.createElement("div");
+    line.className = "fc-event-line";
+    line.textContent = `Peak instability ${ev.peak_cape} J/kg · peak gusts ${ev.peak_gust} km/h`;
+    wrap.appendChild(line);
+  }
+  if (ev.probability != null) {
+    const meter = document.createElement("div");
+    meter.className = "fc-meter";
+    meter.innerHTML = `<span style="width:${Math.max(2, Math.min(100, ev.probability))}%"></span>`;
+    wrap.appendChild(meter);
+    const line = document.createElement("div");
+    line.className = "fc-event-line";
+    line.textContent = `${ev.probability}% chance of precipitation`;
+    wrap.appendChild(line);
+  }
+  const agree = document.createElement("div");
+  agree.className = "fc-agree";
+  agree.textContent = FC_AGREEMENT[ev.agreement] || "";
+  wrap.appendChild(agree);
+  return wrap;
+}
+
+async function renderForecast() {
+  document.getElementById("sidebar").innerHTML = "";
+  const area = document.getElementById("player-area");
+  area.innerHTML = `<div id="empty">Loading forecast&hellip;</div>`;
+
+  let data;
+  try {
+    const res = await fetch("/api/forecast");
+    data = await res.json();
+    if (data.error) throw new Error(data.error);
+  } catch (err) {
+    area.innerHTML = `<div id="empty">Forecast unavailable.<br>${err.message}</div>`;
+    return;
+  }
+
+  const view = document.createElement("div");
+  view.id = "forecast-view";
+
+  const nDays = (data.days || []).length;
+  const generated = data.generated_at
+    ? new Date(data.generated_at).toLocaleString([], {month: "short", day: "numeric",
+                                                     hour: "numeric", minute: "2-digit"})
+    : "unknown";
+  const head = document.createElement("div");
+  head.className = "fc-head";
+  head.innerHTML = `<div class="fc-title">Next ${nDays} days</div>
+    <div class="fc-sub">${data.timezone || "local time"} &middot; updated ${generated}</div>`;
+  view.appendChild(head);
+
+  if (data.stale) {
+    const note = document.createElement("div");
+    note.className = "fc-note";
+    note.textContent = `The weather services aren't responding right now, so this is the `
+      + `last forecast that came through — about ${data.stale_minutes} minutes old.`;
+    view.appendChild(note);
+  }
+  (data.warnings || []).forEach(w => {
+    const note = document.createElement("div");
+    note.className = "fc-note";
+    note.textContent = w;
+    view.appendChild(note);
+  });
+
+  const list = document.createElement("div");
+  list.className = "fc-days";
+  (data.days || []).forEach(day => {
+    const {label, when} = fcDayLabel(day.date, day.lead_days);
+    const leadClass = day.lead_days <= 2 ? "lead-near" : day.lead_days <= 6 ? "lead-mid" : "lead-far";
+
+    if (!day.events.length) {
+      const row = document.createElement("div");
+      row.className = "fc-day quiet";
+      row.innerHTML = `<span class="fc-date">${label}</span>
+        <span class="fc-when">${when}</span>
+        <span class="fc-nothing">nothing expected</span>`;
+      list.appendChild(row);
+      return;
+    }
+
+    const det = document.createElement("details");
+    det.className = `fc-day ${leadClass}`;
+    // Near-term days with something happening open by default — that's the
+    // part you'd actually act on.
+    det.open = day.lead_days <= 2;
+    const summary = document.createElement("summary");
+    summary.innerHTML = `<span class="fc-date">${label}</span><span class="fc-when">${when}</span>`;
+    const chips = document.createElement("span");
+    chips.className = "fc-chips";
+    day.events.forEach(ev => chips.appendChild(fcChip(ev)));
+    summary.appendChild(chips);
+    det.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "fc-body";
+    day.events.forEach(ev => body.appendChild(fcEventDetail(ev)));
+    if (!day.nws_covered && day.events.some(e => !fcIsMoon(e.kind))) {
+      const line = document.createElement("div");
+      line.className = "fc-agree";
+      line.textContent = "This far out only one forecast model reaches, so treat it as a heads-up "
+        + "rather than a plan — it should firm up over the next few days.";
+      body.appendChild(line);
+    }
+    det.appendChild(body);
+    list.appendChild(det);
+  });
+  view.appendChild(list);
+
+  if (data.next_full_moon) {
+    const foot = document.createElement("div");
+    foot.className = "fc-footnote";
+    const [y, m, d] = data.next_full_moon.date.split("-").map(Number);
+    foot.textContent = `Next full moon after this window: ${MONTH_NAMES[m - 1]} ${d}, `
+      + `${data.next_full_moon.days_away} days past the last day shown.`;
+    view.appendChild(foot);
+  }
+
+  area.innerHTML = "";
+  area.appendChild(view);
 }
 
 async function renderStorage() {
@@ -878,6 +1185,7 @@ function numberField(path, opts) {
   input.type = "number";
   if (opts.step) input.step = opts.step;
   if (opts.min != null) input.min = opts.min;
+  if (opts.max != null) input.max = opts.max;
   input.value = cfgGet(path, opts.default != null ? opts.default : 0);
   input.oninput = () => cfgSet(path, input.value === "" ? null : parseFloat(input.value));
   return input;
@@ -1759,6 +2067,29 @@ function buildEventsSection() {
     + "single failed check ends a storm burst early. Set 0 to disable.",
     numberField("events.stale_grace_minutes", {default: 15, min: 0})));
   sec.appendChild(tuning);
+
+  const fc = document.createElement("div");
+  fc.className = "cfg-subsection";
+  const fh = document.createElement("h4");
+  fh.textContent = "Forecast tab";
+  fc.appendChild(fh);
+  const fintro = document.createElement("div");
+  fintro.className = "cfg-hint-block";
+  fintro.textContent = "The Forecast tab shows storms, snow, and moon events coming up. It only reads "
+    + "forecasts — it never changes what gets captured. The thresholds above decide what counts as a "
+    + "forecast storm too, so what it predicts matches what actually gets tagged.";
+  fc.appendChild(fintro);
+
+  fc.appendChild(fieldRow("Days ahead",
+    "How far ahead to look, up to 10. Open-Meteo forecasts 10 days out; the US National Weather "
+    + "Service forecast used to double-check it only reaches about 7, so days 8-10 rest on a single "
+    + "model — the tab marks those days rather than pretending they're as solid as tomorrow.",
+    numberField("events.forecast_days", {default: 10, min: 1, max: 10})));
+  fc.appendChild(fieldRow("Minimum snow (cm)",
+    "How much snow has to be expected across a day before it's worth showing. A dusting that melts "
+    + "on contact makes a dull timelapse; the default is roughly \"you can see it settling\".",
+    numberField("events.forecast_snow_cm_min", {default: 0.5, min: 0, step: "0.1"})));
+  sec.appendChild(fc);
 
   return sec;
 }


### PR DESCRIPTION
The forward-looking counterpart to the Events tab — the next 10 days of what's
worth pointing a camera at, so a storm can be planned for rather than
discovered afterwards.

Built by a background agent; **reviewed and verified against the live APIs**
before merge, with one fix applied (below).

## How it works

Storms are detected by applying the *same* CAPE / gust / precipitation
thresholds used for live tagging (#13) to forecast hours, so a forecast storm
means what a detected storm means, and retuning the thresholds retunes both. The
check runs per hour rather than per day, since a day's peak instability and its
heaviest rain can be twelve hours apart.

Rather than invent a confidence score, the tab surfaces what the forecasts
actually said — probability of precipitation, whether Open-Meteo and the NWS
agree, and how far out the day is. NWS reaches ~7 days and Open-Meteo 10, so
days 8–10 are marked single-source. Moon events are *computed*, not predicted,
so they carry no percentage.

## Fix applied during review

The tab consulted neither `events.weather_enabled` nor `events.lunar_enabled`,
so a deployment with weather tagging **off** still sent its coordinates to
Open-Meteo and the NWS whenever anyone opened the tab, and one with lunar
tagging off still triggered the ~17 MB ephemeris download. There was no separate
switch for the tab, so there was no way to opt out of those calls at all. Both
flags are now honoured, matching `events.py` semantics. With weather off the tab
makes **0 HTTP requests instead of 3**, and explains which switch is off rather
than just looking like a calm ten days.

## Verification

Exercised against the real Open-Meteo and NWS APIs, not mocks:

| check | result |
|---|---|
| live forecast | 5 storm days detected, next full moon 2026-08-27 |
| caching | 3 requests cold, **0 warm** (30 min TTL, 12h stale fallback) |
| no location | degrades to moon-only with a clear warning |
| non-US (Sydney) | Open-Meteo only; NWS correctly `available: false` |
| all network down | warning, no crash, no empty-forecast-as-truth |
| UI vs API | rendered days match the endpoint exactly |

Also confirmed the UI's apparent disagreement with the API on one day was real
forecast movement between calls, not hidden filtering.

Merged `main` in (resolving a CHANGELOG collision with #12/#13/#14) and re-ran
the storm-detection, per-camera-window, and night-build suites against the
combined tree — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)