### PR TITLE
Selective video deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Delete a video straight from the player.** A **delete** button next to
+  **download** removes the selected daily, yearly, or event video from disk —
+  useful for clearing out a junk clip (camera glare, a false storm trigger)
+  the moment you spot it, instead of waiting for retention settings to catch
+  it. New `DELETE /api/videos/<camera>/<vtype>/<name>`, gated by the same
+  optional Config-page passcode as every other write endpoint (`/api/config`,
+  `/api/restart`) — with no passcode set, deletion is open to the LAN, same as
+  those. Deleting an event clip also drops its `events.jsonl` entry
+  immediately rather than waiting for the next nightly build to notice it's
+  gone. `/videos/<camera>/<vtype>/<name>` (the unauthenticated browse route)
+  now validates the camera name too, closing a gap where only `name` and
+  `vtype` were checked. Existing configs are unaffected.
+
 ## [0.3.0] - 2026-08-08
 
 ### Security

--- a/build_timelapse.py
+++ b/build_timelapse.py
@@ -377,19 +377,34 @@ def prune_event_videos(cfg):
                     log.info("%s: pruned event video %s (older than %d days)",
                               cam["name"], f.name, days)
 
+    sync_events_index(cfg)
+
+
+def sync_events_index(cfg):
+    """Drop events.jsonl entries whose clip is no longer on disk. Returns the
+    number dropped.
+
+    Two things remove clips behind the index's back — age pruning above, and a
+    manual delete from the web UI — so both call this rather than each growing
+    its own copy of the reconciliation.
+    """
     index_path = cfg["storage"]["root"] / "events.jsonl"
     if not index_path.exists():
-        return
-    kept = []
+        return 0
+    kept, dropped = [], 0
     for line in index_path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         entry = json.loads(line)
         if (videos_dir(cfg) / entry["video"]).exists():
             kept.append(entry)
-    with open(index_path, "w", encoding="utf-8") as f:
-        for entry in kept:
-            f.write(json.dumps(entry) + "\n")
+        else:
+            dropped += 1
+    if dropped:
+        with open(index_path, "w", encoding="utf-8") as f:
+            for entry in kept:
+                f.write(json.dumps(entry) + "\n")
+    return dropped
 
 
 def tag_spans(cfg, date, tag, gap_minutes=20):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -55,6 +55,27 @@ ACCENT_COLORS = {
 
 REQUIRED_SECTIONS = ("capture", "storage", "daily_video", "yearly")
 
+
+def video_path(cfg, camera, vtype, name):
+    """Resolved path to one video, or None if any component is unsafe/unknown.
+
+    Both the browse and delete routes resolve through this so they agree on
+    exactly what a valid video path is: a known type, a config-shaped camera
+    name, a bare .mp4 leaf with no directory part, and a final resolved path
+    still inside videos_dir. The last check is belt-and-braces — the ones
+    above already make traversal impossible — but it means a future caller
+    can't reintroduce it by loosening one of them.
+    """
+    if vtype not in VIDEO_TYPES:
+        return None
+    if not CAMERA_NAME_RE.match(camera or ""):
+        return None
+    if not name.endswith(".mp4") or name != Path(name).name:
+        return None
+    root = videos_dir(cfg).resolve()
+    path = (root / camera / vtype / name).resolve()
+    return path if path.is_relative_to(root) else None
+
 # Keep in sync with capture.py's MIN_INTERVAL_SECONDS — the floor on poll rate.
 MIN_INTERVAL_SECONDS = 10
 
@@ -750,11 +771,37 @@ def create_app(cfg, config_path=None):
 
     @app.get("/videos/<camera>/<vtype>/<name>")
     def serve_video(camera, vtype, name):
-        if vtype not in VIDEO_TYPES or not name.endswith(".mp4"):
+        path = video_path(state["cfg"], camera, vtype, name)
+        if path is None:
             abort(404)
-        # send_from_directory rejects path traversal and handles Range
-        # requests, which the <video> element needs for seeking.
-        return send_from_directory(videos_dir(state["cfg"]) / camera / vtype, name)
+        # send_from_directory handles Range requests, which <video> seeking needs.
+        return send_from_directory(path.parent, path.name)
+
+    @app.delete("/api/videos/<camera>/<vtype>/<name>")
+    @require_config_auth
+    def delete_video(camera, vtype, name):
+        cfg = state["cfg"]
+        path = video_path(cfg, camera, vtype, name)
+        if path is None or not path.is_file():
+            return jsonify({"error": "no such video"}), 404
+        try:
+            path.unlink()
+        except OSError as exc:
+            return jsonify({"error": f"failed to delete {path.name}: {exc}"}), 500
+
+        result = {"ok": True, "deleted": f"{camera}/{vtype}/{name}"}
+        if vtype == "events":
+            # events.jsonl indexes clips by path; a deleted clip must leave the
+            # index in the same request, not 24h later on the next nightly build.
+            try:
+                import build_timelapse
+                result["index_entries_removed"] = build_timelapse.sync_events_index(cfg)
+            except Exception as exc:
+                app.logger.exception("events index sync failed after deleting %s", path.name)
+                result["warning"] = (
+                    f"{path.name} was deleted, but the events index could not be "
+                    f"updated ({exc}). It will self-heal on the next nightly build.")
+        return jsonify(result)
 
     return app
 

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -235,6 +235,12 @@
   .speed.active { color: var(--accent); border-color: var(--accent); }
   a.dl { color: var(--text-2); font-size: var(--fs-sm); text-decoration: none; }
   a.dl:hover { color: var(--accent); }
+  button.del {
+    background: none; border: 0; padding: 0;
+    color: var(--text-2); font: inherit; font-size: var(--fs-sm);
+    cursor: pointer;
+  }
+  button.del:hover { color: #e5534b; }
 
   #empty { color: var(--text-2); text-align: center; padding: var(--space-6); line-height: 1.6; }
   #empty code {
@@ -739,6 +745,7 @@ function play(v, itemEl) {
         ${[0.5, 1, 2, 4].map(s =>
           `<button class="speed${s === 1 ? " active" : ""}" data-speed="${s}">${s}&times;</button>`).join("")}
         <a class="dl" href="${v.url}" download>download</a>
+        <button class="del" title="Delete this video from disk">delete</button>
       </div>
     </div>`;
   area.querySelectorAll(".speed").forEach(b => {
@@ -748,6 +755,42 @@ function play(v, itemEl) {
       b.classList.add("active");
     };
   });
+  area.querySelector(".del").onclick = async () => {
+    if (!confirm(`Delete ${v.camera} ${v.label} (${v.size_mb} MB) from disk?\n\n`
+                 + deleteHint(v))) return;
+    const url = `/api/videos/${encodeURIComponent(v.camera)}/${v.type}`
+              + `/${encodeURIComponent(v.label)}.mp4`;
+    let res, data;
+    try {
+      res = await fetch(url, {method: "DELETE"});
+      data = await res.json();
+    } catch (e) { alert("Delete failed: " + e); return; }
+    if (res.status === 401) {
+      alert("Deleting a video needs the Config-page passcode — open the Config tab and sign in first.");
+      return;
+    }
+    if (data.error) { alert("Delete failed: " + data.error); return; }
+    if (data.warning) alert(data.warning);
+    state.videos = state.videos.filter(
+      x => !(x.camera === v.camera && x.type === v.type && x.label === v.label));
+    renderList();
+  };
+}
+
+// What deleting each video type actually costs. The rules differ: yearly
+// videos are always rebuildable (their frame archive is never pruned), daily
+// and event videos only while their source snapshots survive
+// storage.keep_snapshots_days.
+function deleteHint(v) {
+  if (v.type === "yearly") {
+    return `You can rebuild it any time: build_timelapse.py yearly --year ${v.label} --force`;
+  }
+  const date = (v.label.match(/^\d{4}-\d{2}-\d{2}/) || [])[0];
+  const cmd = v.type === "events"
+    ? `build_timelapse.py events --date ${date} --camera ${v.camera}`
+    : `build_timelapse.py daily --date ${date} --camera ${v.camera}`;
+  return `Rebuildable with \`${cmd}\` only while that day's snapshot frames still exist. `
+       + `Otherwise this is permanent.`;
 }
 
 function fmtGB(n) {


### PR DESCRIPTION
## Summary
- New `DELETE /api/videos/<camera>/<vtype>/<name>`, gated by the same optional Config-page passcode as every other write endpoint — with no passcode set, deletion is open to the LAN, same as everything else.
- A **delete** button next to **download** in the player removes the selected daily, yearly, or event video from disk, with a confirmation dialog stating what's actually regenerable and how.
- Deleting an event clip also drops its `events.jsonl` entry immediately rather than waiting for the next nightly build to notice it's gone.
- `/videos/<camera>/<vtype>/<name>` (the unauthenticated browse route) now validates the camera name too, closing a gap where only `name` and `vtype` were checked.

Existing configs are unaffected.

## Test plan
- [x] Live-tested: deleted daily/yearly/event videos against a real running instance, confirmed file removal, `events.jsonl` sync, and 404 on re-delete
- [x] Path-traversal and invalid-input cases (bad camera name, bad type, `../` attempts) verified to 404
- [x] Auth gating verified with and without a Config-page passcode set
- [x] Semgrep (`p/python`, `p/security-audit`, `p/secrets`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)