### PR TITLE
Bundle release notes and wiki updates into the release process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,4 +13,6 @@ __pycache__/
 .claude/
 deploy/
 scan-results/
+scripts/
+wiki/
 *.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+# Fired by pushing a vX.Y.Z tag — the same single action that already triggers
+# the container images in publish-image.yml. Everything else a release needs
+# happens here, so a release is one action instead of four manual ones:
+#   1. guard  — VERSION and CHANGELOG.md must agree with the tag
+#   2. notes  — publish a GitHub Release whose body IS the CHANGELOG section
+#   3. wiki   — mirror wiki/ in this repo onto the GitHub wiki
+#
+# Maintainer process (unchanged except that steps 3 and 4 collapse into one):
+#   1. branch release/X.Y.Z — move [Unreleased] into ## [X.Y.Z] - YYYY-MM-DD,
+#      bump VERSION, and edit wiki/*.md for anything this release changes
+#   2. merge the PR to main
+#   3. git tag vX.Y.Z && git push origin vX.Y.Z
+#
+# WIKI PAGES ARE EDITED IN wiki/ IN THIS REPO, NOT IN THE BROWSER. This job
+# mirrors wiki/ over the wiki repo, so a page edited on github.com is
+# overwritten — or deleted — by the next release.
+
+on:
+  push:
+    tags: ["v*"]
+
+# contents: write covers both creating the release and pushing to
+# <repo>.wiki.git. Declaring any permissions block resets everything else to
+# none, so this has to be explicit.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: VERSION must match the tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          file="$(tr -d '[:space:]' < VERSION)"
+          if [ "$tag" != "$file" ]; then
+            echo "::error::VERSION is '$file' but the tag is '$GITHUB_REF_NAME'." \
+                 "Bump VERSION on main and retag, or delete this tag."
+            exit 1
+          fi
+
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          python3 scripts/changelog_section.py "$GITHUB_REF_NAME" > release-notes.md
+          echo "--- release notes ---"
+          cat release-notes.md
+
+      # Idempotent so a re-run after a transient failure updates the release
+      # instead of erroring on "already exists".
+      - name: Publish the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" \
+              --title "ReoLapse $GITHUB_REF_NAME" --notes-file release-notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "ReoLapse $GITHUB_REF_NAME" --notes-file release-notes.md
+          fi
+
+      # ref: master is required — a wiki repo's default branch is master and
+      # has no vX.Y.Z tag, so checkout's default (github.ref) would fail.
+      - name: Check out the wiki repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+          ref: master
+          path: wiki-repo
+
+      - name: Mirror wiki/ onto the wiki
+        run: |
+          if ! ls wiki/*.md >/dev/null 2>&1; then
+            echo "::error::wiki/ contains no .md pages — refusing to wipe the live wiki."
+            exit 1
+          fi
+          find wiki-repo -maxdepth 1 -name '*.md' -delete
+          cp wiki/*.md wiki-repo/
+          cd wiki-repo
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "wiki already matches wiki/ at $GITHUB_REF_NAME — nothing to push"
+          else
+            git commit -m "Sync wiki from $GITHUB_REF_NAME ($GITHUB_SHA)"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -269,7 +269,10 @@ default to being kept forever — a reference 3-camera deployment grows about
 and a shortage/headroom forecast. Full sizing numbers and the retention math
 are on the
 [Storage & Performance](https://github.com/SeriesOfTubez/reolapse/wiki/Storage-and-Performance#storage-estimates)
-wiki page.
+wiki page. Spot a junk video? A **delete** button next to **download** in the
+player removes it from disk — see
+[Deleting a video by hand](https://github.com/SeriesOfTubez/reolapse/wiki/Storage-and-Performance#deleting-a-video-by-hand)
+for what's regenerable and what isn't.
 
 ## Performance
 
@@ -302,7 +305,11 @@ than trusting a single weather code, since thunderstorm conditions are
 otherwise under-reported — a real deployment logged zero storm tags over 19
 days of repeated storms before this. See the
 [Weather & Storm Detection](https://github.com/SeriesOfTubez/reolapse/wiki/Weather-and-Storm-Detection)
-wiki page for how detection works and how API outages are handled.
+wiki page for how detection works and how API outages are handled. Those
+same burst frames make the daily video crawl through a storm hour by
+default; `daily_video.include_events` controls whether they're woven in or
+left out — see
+[Event frames in the daily video](https://github.com/SeriesOfTubez/reolapse/wiki/Weather-and-Storm-Detection#event-frames-in-the-daily-video).
 
 ## Lunar event detection
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,11 @@ judge for yourself rather than take it on faith:
 Issues and PRs welcome — especially reports of which Reolink models work. Keep
 changes focused and match the existing style.
 
+Wiki pages live in [`wiki/`](wiki/) in this repo and are published to the
+GitHub wiki automatically when a release tag is pushed — **edit them there in
+a PR, not in the browser**, or your changes will be overwritten by the next
+release.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Print CHANGELOG.md's section for one version, for use as release notes.
+
+    python scripts/changelog_section.py 0.4.0
+
+Exits 1 with a message on stderr if there is no `## [X.Y.Z]` heading for that
+version, or the section under it is empty. A release published with the wrong
+notes is worse than one that fails to publish.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
+
+
+def section(text, version):
+    """The body under `## [version] ...`, up to the next `## ` heading."""
+    pattern = re.compile(
+        r"^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^## |\Z)", re.S | re.M)
+    match = pattern.search(text)
+    return match.group(1).strip() if match else None
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: changelog_section.py X.Y.Z")
+    version = sys.argv[1].lstrip("v")
+    body = section(CHANGELOG.read_text(encoding="utf-8"), version)
+    if body is None:
+        sys.exit(f"CHANGELOG.md has no '## [{version}]' section — add one before tagging.")
+    if not body:
+        sys.exit(f"CHANGELOG.md's '## [{version}]' section is empty — write the notes first.")
+    print(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -12,6 +12,7 @@ not: reference them as `${VAR}` and put the values in `.env`. Highlights:
 | `cameras[].daylight_window` | Per-camera day/night schedule; each key falls back to `capture.daylight_window` — see [Per-camera schedules](PTZ-and-Night-Capture#per-camera-schedules) |
 | `cameras[].interval_seconds` | Per-camera capture cadence; falls back to `capture.interval_seconds` |
 | `cameras[].events_enabled` | `false` makes a camera ignore events entirely — no burst capture, no event clips (default `true`) — see [Cameras that sit out events](PTZ-and-Night-Capture#cameras-that-sit-out-events) |
+| `cameras[].include_events_in_daily` | Per-camera override of `daily_video.include_events`; omit the key to follow the global setting |
 | `capture.timezone` | IANA timezone for capture timing/day boundaries; blank auto-detects from location, else falls back to the host clock |
 | `capture.interval_seconds` | Base capture cadence (default 60, minimum 10) |
 | `capture.start_time`/`end_time` | Optional fixed daily capture window |
@@ -19,6 +20,7 @@ not: reference them as `${VAR}` and put the values in `.env`. Highlights:
 | `storage.keep_snapshots_days` | Retention for raw frames after their video builds |
 | `daily_video.deflicker_size` | Deflicker window; `0` disables |
 | `daily_video.retention_days` | Delete a daily video this many days after its date; `0` = forever |
+| `daily_video.include_events` | Weave storm/snow **burst** frames into the daily video (default `false`) — see [Event frames in the daily video](Weather-and-Storm-Detection#event-frames-in-the-daily-video) |
 | `yearly.min_days_before_render` | Wait until this many days are archived before rendering the yearly video (default 30); `0` renders as soon as any frames exist, `yearly --force` overrides once |
 | `yearly.video_frames_per_day` / `video_window` | Pacing of the yearly video |
 | `yearly.retention_years` | Delete a yearly video once it's this many years old; `0` = forever. Cheap to set low — see [Storage estimates](Storage-and-Performance#storage-estimates) |

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -1,0 +1,99 @@
+# Configuration Reference
+
+## Configuration
+
+Everything lives in `config.yaml` (copy from `config.example.yaml`). Secrets do
+not: reference them as `${VAR}` and put the values in `.env`. Highlights:
+
+| Key | Meaning |
+|---|---|
+| `cameras[].host` / `channel` | Camera IP + `0`, or NVR IP + channel number |
+| `cameras[].ptz_home` | Quarantine frames taken off a PTZ camera's home position |
+| `cameras[].daylight_window` | Per-camera day/night schedule; each key falls back to `capture.daylight_window` — see [Per-camera schedules](PTZ-and-Night-Capture#per-camera-schedules) |
+| `cameras[].interval_seconds` | Per-camera capture cadence; falls back to `capture.interval_seconds` |
+| `cameras[].events_enabled` | `false` makes a camera ignore events entirely — no burst capture, no event clips (default `true`) — see [Cameras that sit out events](PTZ-and-Night-Capture#cameras-that-sit-out-events) |
+| `capture.timezone` | IANA timezone for capture timing/day boundaries; blank auto-detects from location, else falls back to the host clock |
+| `capture.interval_seconds` | Base capture cadence (default 60, minimum 10) |
+| `capture.start_time`/`end_time` | Optional fixed daily capture window |
+| `capture.daylight_window` | Capture only around actual sunrise/sunset instead of a fixed clock window — see [Night capture & IR cameras](PTZ-and-Night-Capture#night-capture--ir-cameras) |
+| `storage.keep_snapshots_days` | Retention for raw frames after their video builds |
+| `daily_video.deflicker_size` | Deflicker window; `0` disables |
+| `daily_video.retention_days` | Delete a daily video this many days after its date; `0` = forever |
+| `yearly.min_days_before_render` | Wait until this many days are archived before rendering the yearly video (default 30); `0` renders as soon as any frames exist, `yearly --force` overrides once |
+| `yearly.video_frames_per_day` / `video_window` | Pacing of the yearly video |
+| `yearly.retention_years` | Delete a yearly video once it's this many years old; `0` = forever. Cheap to set low — see [Storage estimates](Storage-and-Performance#storage-estimates) |
+| `events.weather_enabled` | Storm/snow/rain tagging + burst capture (needs `events.zip` or `latitude`/`longitude`) |
+| `events.lunar_enabled` | Moon-event tagging — no location required |
+| `events.season_enabled` | Spring/summer/fall/winter tagging on frames + video metadata — no location required |
+| `events_video.tags` | Which tags get their own `<date>_<tag>.mp4` clip (default `storm`, `snow`; any tag works, including moon events) |
+| `events_video.deflicker_size` / `deflicker_by_tag` | Deflicker for event clips — off by default (protects lightning in storm clips), overridable per tag (e.g. enable for `snow`) |
+| `events_video.retention_days` | Delete an event clip this many days after its date; `0` = forever |
+| `webapp.accent_color` | UI accent color: `amber` (default), `green`, `blue`, `red`, `purple`, `yellow` |
+
+See the inline comments in `config.example.yaml` for the full reference.
+
+## Config page & network discovery
+
+The **Config** tab edits `config.yaml` from the browser instead of by hand —
+every setting above except secrets (see below) is exposed as a checkbox,
+dropdown, radio, or text field.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/SeriesOfTubez/reolapse/main/assets/screenshot-config.png" width="820" alt="ReoLapse Config page: editing a camera in the browser — name, host, channel, username, a password field that's a dropdown of .env variable references, and HTTPS / verify-SSL toggles, with Save config and Restart services buttons">
+</p>
+
+- **Passwords are always a variable reference, never a real value, in the
+  UI.** Each camera's password field is a dropdown of `REOLINK_PASSWORD*`
+  variables this server has loaded from `.env` (names only — the actual
+  values never reach the browser); pick one, or choose "Custom" to reference
+  a variable you haven't added to `.env` yet. The save endpoint independently
+  rejects anything that isn't a `${VAR}` reference, so a literal password
+  typed into the form can't end up in `config.yaml` even if the UI is
+  bypassed.
+- **Fields the UI doesn't have a control for are preserved as-is.** The page
+  edits the config it fetched in place rather than rebuilding it from
+  scratch, so things like a camera's `ptz_home` block or
+  `events_video.deflicker_by_tag` survive a save untouched even though
+  there's no form control for them yet.
+- **Saving does not restart anything by itself.** The web UI picks up most
+  changes on next page load (accent color is immediate), but `capture.py` and
+  `build_timelapse.py` are separate processes — they only pick up a saved
+  change after a restart.
+- **Restart services button.** On a systemd deployment, the Config page's
+  footer has a **Restart services** button that runs
+  `systemctl restart reolapse-capture.service` and
+  `reolapse-web.service` for you, so you don't need shell access just to
+  apply a config change. It requires a narrowly-scoped passwordless sudo rule
+  (only those two restart commands, nothing else). The **easy installer sets
+  this up automatically**; for a manual install, install the ready-made
+  `deploy/reolapse.sudoers` drop-in (see
+  [Installation](Installation#install-on-a-linux-vm-systemd)). Without the rule
+  the button just fails with a clear error instead of hanging. Docker
+  deployments don't have `systemctl` at all — the button detects this and
+  tells you to run `docker compose restart` instead.
+- **Comments are not preserved.** This editor round-trips the YAML as data,
+  not text, so saving from the UI strips out `config.yaml`'s hand-written
+  comments. A backup of the previous file is written to `config.yaml.bak`
+  before every save.
+- **Config page access (optional passcode).** The **Config page access**
+  section at the bottom of the page lets you set a single passcode that gates
+  this page and its write/scan endpoints — video browsing stays open. Setting
+  the first passcode is allowed from the open page (it logs you straight in);
+  changing or removing it afterward requires being logged in. See
+  [Security](Security) for how it's stored and what it does and doesn't
+  protect. Setting or changing the passcode also rewrites `config.yaml` (same
+  `.bak` backup, same comment-stripping caveat as above).
+- **Network discovery** (inside the Cameras section) scans your `/24` for
+  Reolink devices and lists the ones it finds. An unauthenticated probe can
+  only confirm a device is there, not what it is — click **Identify & add**
+  on a result, supply credentials, and it fetches the real model/name/channel
+  list before adding anything. The credentials you type there are used for
+  that one lookup only and are never saved; you still need to add the real
+  password to `.env` yourself before restarting capture. If a scan seems to
+  miss a device, try it again — the first scan after a service restart can
+  occasionally undercount on constrained hardware (observed on a 1-vCPU
+  reference VM; consistently found everything on immediate re-runs).
+  Discovery only sees whatever network the server itself is on — inside
+  Docker's default bridge network, that's the container's private subnet,
+  not your LAN; run outside Docker or add `network_mode: host` if you want
+  discovery to work in a container.

--- a/wiki/Forecast-Tab.md
+++ b/wiki/Forecast-Tab.md
@@ -1,0 +1,75 @@
+# Forecast Tab (what's coming)
+
+The Events tab is backward-looking: clips already cut from storms that
+happened. The **Forecast** tab is its counterpart — the next 10 days of
+storms, snow, and moon events, so you can plan around them.
+
+It is read-only. It never changes what gets captured, never triggers a burst,
+and writes nothing. It exists to answer "is anything worth watching for this
+week?"
+
+## It agrees with what actually gets tagged
+
+A forecast storm means exactly what a detected storm means, because it's the
+same test: the CAPE, gust, and precipitation thresholds under
+[How a storm is detected](Weather-and-Storm-Detection#how-a-storm-is-detected)
+are applied to forecast hours instead of the current hour. Retune those
+thresholds and the Forecast tab retunes with them.
+
+The check runs per *hour*, not per day. Open-Meteo also publishes daily
+aggregates, but a day's peak instability and its heaviest rain can be twelve
+hours apart, and pairing them would invent storms that no actual hour
+supports.
+
+## Confidence, and why there's no confidence score
+
+Your day-8 storm is a maybe; tomorrow's is close to a fact. Rather than
+compress that into a number we made up, the tab shows the things the
+forecasts actually said:
+
+- **Probability of precipitation**, straight from the APIs.
+- **Whether the two sources agree.** Open-Meteo and the US National Weather
+  Service are independent forecasts. "Both forecasts agree" is meaningfully
+  stronger than "Open-Meteo only — the NWS forecast doesn't show it", and the
+  tab says which it is.
+- **How far out it is**, both in words ("in 3 days") and as the weight of the
+  stripe down the left edge of each day.
+
+NWS forecasts reach about 7 days; Open-Meteo reaches 10. Days 8-10 therefore
+rest on a single model, and the tab marks them rather than letting them look
+as solid as tomorrow. Outside the US, NWS has no data at all — Open-Meteo
+carries the whole forecast and every day is marked single-source.
+
+Moon events are handled differently on purpose. They're computed from an
+ephemeris, not predicted, so a full moon nine days out is exactly as certain
+as one tomorrow. They get no percentage, no probability bar, and no
+"treat this as a heads-up" caveat — just a solid chip and the note that it's
+calculated rather than forecast.
+
+## Degrading gracefully
+
+These are free services and they hand out 502s, 503s, and timeouts routinely.
+
+- The forecast is cached for 30 minutes, so browsing the UI doesn't hammer
+  them — a page load costs nothing.
+- If a refresh fails, the last good forecast keeps being served, labelled with
+  its age. This matters more than it sounds: a failed fetch produces a
+  perfectly well-formed forecast with *no storms in it*, which is
+  indistinguishable from a genuinely calm week. Serving that would quietly
+  tell you "nothing coming" when the truth is "we couldn't ask" — the same
+  trap `stale_grace_minutes` avoids for live capture.
+- With no location configured, weather is skipped and the tab still shows moon
+  events, with a note explaining what to set.
+
+## Settings
+
+Both live under `events:` in `config.yaml`, and both are editable from the
+Config page:
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `forecast_days` | `10` | How far ahead to look, 1-10. Set it to `7` to show only days both forecasts cover. |
+| `forecast_snow_cm_min` | `0.5` | Snow across a day before it's worth showing. A dusting that melts on contact makes a dull timelapse. |
+
+The storm thresholds are shared with live detection and documented under
+[How a storm is detected](Weather-and-Storm-Detection#how-a-storm-is-detected).

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -6,9 +6,9 @@ Deep-reference docs for ReoLapse. Start with the [README](https://github.com/Ser
 
 - **[Installation](Installation)** — Linux VM (systemd) install (easy + manual), Docker reference, and upgrading
 - **[Configuration Reference](Configuration-Reference)** — every `config.yaml` field, plus the Config page & network discovery
-- **[Weather & Storm Detection](Weather-and-Storm-Detection)** — storm bursts, how storms are detected, surviving API outages
+- **[Weather & Storm Detection](Weather-and-Storm-Detection)** — storm bursts, how storms are detected, surviving API outages, event frames in the daily video
 - **[Lunar & Season Tagging](Lunar-and-Season-Tagging)** — moon events and astronomical season tags
 - **[Forecast Tab](Forecast-Tab)** — the 10-day storm/snow/moon forecast
 - **[PTZ & Night Capture](PTZ-and-Night-Capture)** — PTZ quarantine, IR/night handling, per-camera schedules
-- **[Storage & Performance](Storage-and-Performance)** — disk sizing, retention math, build times
+- **[Storage & Performance](Storage-and-Performance)** — disk sizing, retention math, build times, deleting videos
 - **[Security](Security)** — the auth model, the Config-page passcode, and what's *not* protected

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,14 @@
+# ReoLapse Wiki
+
+Deep-reference docs for ReoLapse. Start with the [README](https://github.com/SeriesOfTubez/reolapse#readme) for an overview, screenshots, features, and the Docker quick start — this wiki covers everything past that.
+
+## Pages
+
+- **[Installation](Installation)** — Linux VM (systemd) install (easy + manual), Docker reference, and upgrading
+- **[Configuration Reference](Configuration-Reference)** — every `config.yaml` field, plus the Config page & network discovery
+- **[Weather & Storm Detection](Weather-and-Storm-Detection)** — storm bursts, how storms are detected, surviving API outages
+- **[Lunar & Season Tagging](Lunar-and-Season-Tagging)** — moon events and astronomical season tags
+- **[Forecast Tab](Forecast-Tab)** — the 10-day storm/snow/moon forecast
+- **[PTZ & Night Capture](PTZ-and-Night-Capture)** — PTZ quarantine, IR/night handling, per-camera schedules
+- **[Storage & Performance](Storage-and-Performance)** — disk sizing, retention math, build times
+- **[Security](Security)** — the auth model, the Config-page passcode, and what's *not* protected

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,169 @@
+# Installation
+
+> **Running this in a VM?** Make sure the hypervisor exposes at least the
+> x86-64-v2 CPU baseline to the guest — see
+> [Requirements](https://github.com/SeriesOfTubez/reolapse#requirements).
+> Proxmox's default CPU type doesn't; `host` or `x86-64-v3` does.
+
+## Docker
+
+```bash
+git clone https://github.com/SeriesOfTubez/reolapse.git
+cd reolapse
+
+cp config.example.yaml config.yaml   # edit: cameras, location, options
+cp .env.example .env                 # set REOLINK_PASSWORD
+
+docker compose pull && docker compose up -d   # runs the latest release image
+```
+
+This pulls a pre-built multi-arch image (amd64 + arm64, so it works on a
+Raspberry Pi) from `ghcr.io/seriesoftubez/reolapse`. `REOLAPSE_TAG` selects
+which: `latest` (newest release, default), a pinned version like `0.2.0`, or
+`edge` (latest development code from `main`) — e.g.
+`REOLAPSE_TAG=edge docker compose pull && docker compose up -d`. Or **build
+from source** instead, handy for local changes or unreleased code:
+
+```bash
+docker compose up -d --build
+```
+
+Open <http://localhost:8080>. Three services start: `capture` (continuous),
+`scheduler` (nightly/weekly builds), and `web`. Keep `storage.root: ./data` in
+`config.yaml` so data lands on the Docker volume. To upgrade later, see
+[Upgrading](#upgrading) below.
+
+## Install on a Linux VM (systemd)
+
+### Easy install (one command)
+
+For a Debian/Ubuntu host with systemd. Installs the system packages, clones into
+`/opt/reolapse`, sets up the virtualenv, installs and enables the systemd units
+**for the user running the script** (retargeting the units' default `User=`, so
+you don't need an `ubuntu` user), starts the web UI, and (unless you opt out)
+adds the scoped sudo rule for the Config page's Restart button:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SeriesOfTubez/reolapse/main/install.sh | bash
+```
+
+Piping a script into your shell means running it unread — reasonable to look
+first (a good habit for any `curl | bash`):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SeriesOfTubez/reolapse/main/install.sh -o install.sh
+less install.sh
+bash install.sh
+```
+
+By default it installs the **latest stable release**; run interactively it asks
+whether you'd rather have `main` (latest development code). Run it as a normal
+user with sudo — **not** as root. It deliberately stops short of capturing: you
+still fill in `config.yaml` and `.env` (or use the web UI's Config tab), then
+`sudo systemctl start reolapse-capture.service` — the script prints the exact
+next steps.
+
+Env-var options: `REOLAPSE_DIR=` (install location), `REOLAPSE_REF=` (a tag or
+`main` to skip the prompt — e.g. `REOLAPSE_REF=main` for dev code, or
+`REOLAPSE_REF=v0.1.0` to pin a release), `REOLAPSE_YES=1` (non-interactive,
+takes the stable default), `REOLAPSE_SKIP_SUDOERS=1`.
+
+### Manual install
+
+```bash
+sudo mkdir -p /opt/reolapse && sudo chown "$USER" /opt/reolapse
+git clone https://github.com/SeriesOfTubez/reolapse.git /opt/reolapse
+cd /opt/reolapse
+
+sudo apt install -y ffmpeg
+python3 -m venv venv && venv/bin/pip install -r requirements.txt
+
+cp config.example.yaml config.yaml   # edit for your setup
+cp .env.example .env                  # set REOLINK_PASSWORD
+chmod 600 .env config.yaml
+```
+
+**What you must configure** before the services will work:
+
+1. **`config.yaml`** — your cameras (host/channel/name), and optionally location
+   and capture settings. See the
+   [Configuration Reference](Configuration-Reference) for every field.
+2. **`.env`** — set `REOLINK_PASSWORD` (and any extra `REOLINK_PASSWORD_*`) to
+   your real camera/NVR password(s). `config.yaml` only ever references these by
+   name, never the literal value.
+
+Test one capture before wiring up the services (`venv/bin/python capture.py -v` —
+a JPEG should appear under `data/snapshots/…`).
+
+**Then point the systemd units at your setup.** The units in `deploy/` are
+written for the defaults **`User=ubuntu`** and **`/opt/reolapse`** — if either
+differs for you they won't start, so retarget them first:
+
+```bash
+# Set User= to the account the services run as (skip if you really use "ubuntu"):
+sed -i "s/^User=ubuntu$/User=$(id -un)/" deploy/*.service
+
+# Only if you installed somewhere other than /opt/reolapse, fix the paths too:
+# sed -i "s|/opt/reolapse|/your/install/path|g" deploy/*.service
+```
+
+Now install and enable them:
+
+```bash
+sudo cp deploy/*.service deploy/*.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now reolapse-capture.service \
+     reolapse-web.service reolapse-daily.timer reolapse-yearly.timer
+```
+
+Finally, make sure ReoLapse knows your timezone so capture days line up with
+your local midnight: either set `capture.timezone` (an IANA name like
+`America/Chicago`), leave it blank to auto-detect from your `events.zip` /
+latitude-longitude, or set the host clock (`sudo timedatectl set-timezone …`).
+The config option is the most reliable — it doesn't depend on the host clock
+being right.
+
+**(Optional) Enable the Config page's Restart button.** A ready-made, scoped
+sudo drop-in ships in `deploy/`. It also defaults to user `ubuntu`, so set it to
+your account first (and confirm the `systemctl` path matches
+`command -v systemctl` — it's `/usr/bin/systemctl` on most systems), then
+validate and install it:
+
+```bash
+sed -i "s/^ubuntu /$(id -un) /" deploy/reolapse.sudoers   # set your user
+
+sudo visudo -cf deploy/reolapse.sudoers \
+  && sudo install -m 0440 -o root -g root deploy/reolapse.sudoers /etc/sudoers.d/reolapse
+```
+
+## Upgrading
+
+Upgrades only change code — your `config.yaml`, `.env`, and `data/` are
+gitignored (Linux) or on a named volume (Docker), so history and settings are
+never touched.
+
+**Linux (installed with `install.sh`):**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SeriesOfTubez/reolapse/main/upgrade.sh | bash
+```
+
+…or `bash upgrade.sh` from your install dir. It fetches the latest release,
+reinstalls dependencies, refreshes the systemd units, and restarts the
+services. Pin a version with `REOLAPSE_REF=v0.2.0`, or track the tip of `main`
+with `REOLAPSE_REF=main`.
+
+**Docker:**
+
+```bash
+cd /path/to/reolapse
+git pull                                # refresh compose file + docs
+docker compose pull && docker compose up -d   # or: up -d --build to build from source
+```
+
+The `data` volume survives across both. (`git pull` just updates the compose
+file; the actual app comes from the pulled image or a local build.)
+
+Releases are tagged and listed on the
+[Releases page](https://github.com/SeriesOfTubez/reolapse/releases). The running
+version appears in the web UI header and in the capture/web service logs.

--- a/wiki/Lunar-and-Season-Tagging.md
+++ b/wiki/Lunar-and-Season-Tagging.md
@@ -1,0 +1,44 @@
+# Lunar & Season Tagging
+
+## Lunar event detection
+
+With `events.lunar_enabled: true`, ReoLapse computes real moon events — full
+moon, blue moon, harvest moon, and lunar eclipses — using
+[Skyfield](https://rhodesmill.org/skyfield/) and a local JPL ephemeris
+(`de421.bsp`, ~17 MB, downloaded once into `data/ephemeris/`). **No location
+is required**: a full moon happens at the same instant everywhere on Earth,
+so the phase-based tags (`full-moon`, `blue-moon`, `harvest-moon`) work with
+nothing else configured. This does need a CPU meeting the x86-64-v2 baseline
+(see [Requirements](https://github.com/SeriesOfTubez/reolapse#requirements)) —
+on an under-specified VM it fails silently, logging `event source failed: NumPy
+was built with baseline optimizations...` while the rest of ReoLapse keeps
+working normally.
+
+Eclipses are a little more subtle. The eclipse itself is also a geocentric
+event, but *visibility* is not — only the hemisphere facing the Moon at that
+moment can see it. If a location is configured (shared with the weather
+settings), an eclipse is only tagged `blood-moon` (total) or `lunar-eclipse`
+(partial) when the Moon was actually above your horizon for it; without a
+location, every eclipse is tagged unconditionally since there's nothing to
+check visibility against.
+
+Lunar tags are metadata only by default — they don't trigger burst capture.
+Add them to `events_video.tags` if you want an automatic clip, e.g.
+`2026-03-03_blood-moon.mp4`.
+
+## Season tagging
+
+With `events.season_enabled: true`, every frame and video gets tagged with
+its astronomical season (`spring`/`summer`/`fall`/`winter`), computed from
+the real equinox/solstice instants each year via Skyfield — not a fixed
+calendar approximation. No location is required: it defaults to Northern
+Hemisphere seasons, which is right for most current users; set a location if
+you're south of the equator so the tags flip correctly (July is winter
+there, not summer).
+
+Frames get it the same way as weather/lunar tags — a JPEG comment. Videos
+get it as MP4 metadata (`season=summer`), readable with `ffprobe -show_format`
+or exiftool. If you're curious why that needed a nonstandard `ffmpeg` flag:
+the mov/mp4 muxer only writes a fixed whitelist of "known" keys (`comment`,
+`artist`, …) by default and silently drops anything else, including custom
+keys like `season` — `-movflags use_metadata_tags` turns that off.

--- a/wiki/PTZ-and-Night-Capture.md
+++ b/wiki/PTZ-and-Night-Capture.md
@@ -1,0 +1,129 @@
+# PTZ & Night Capture
+
+## PTZ cameras
+
+Add a `ptz_home` block (see `config.example.yaml`). Before each snapshot,
+capture reads `GetPtzCurPos` and compares pan/tilt to the configured home;
+off-home frames go to an `offposition/` subfolder — excluded from videos, still
+pruned normally. Whichever axes the response includes are checked; an NVR
+relays only pan (usually enough). Set `ptz_home.host` to the camera's own IP if
+you need the tilt axis. The check fails open — a position-query error keeps the
+frame.
+
+## Night capture & IR cameras
+
+If a camera relies on IR illumination at night, a 24-hour daily timelapse
+will show a jarring color-to-black-and-white-and-back transition at the start
+and end of every night — deflicker smooths *exposure* flicker, not a full
+color-mode switch. Two ways to avoid it:
+
+- **Disable IR** if the scene has enough ambient light without it (street
+  lights, a porch light, etc.) — the camera stays in color all night, at the
+  cost of more visible sensor noise in the dark. This is the reference
+  deployment's setup and it works well; see the
+  [Weather tagging](Weather-and-Storm-Detection#weather-tagging--storm-bursts)
+  and [Lunar event detection](Lunar-and-Season-Tagging#lunar-event-detection)
+  wiki pages for why full 24-hour color capture is worth having if you can.
+- **Capture only during daylight** with `capture.daylight_window` if IR needs
+  to stay on. Unlike a fixed `start_time`/`end_time`, this is computed fresh
+  every day from real sunrise/sunset for your location (`events.zip` or
+  `latitude`/`longitude`, independent of whether weather/lunar tagging is
+  enabled), so it tracks the seasons instead of drifting out of sync with
+  them. `buffer_minutes` extends the window a bit past sunrise/sunset on each
+  end, since IR typically doesn't kick in the instant the sun sets — tune it
+  down if you still catch IR frames, or up if you're cutting off usable
+  daylight.
+
+We looked at a third option — asking the camera directly whether it's
+currently in color or IR mode via `GetIsp`'s `dayNight` field — but that
+field is the camera's **configured mode** (`Auto`/`Color`/`Black&White`), not
+a live readout of which one is currently active. For a camera left on
+`Auto` (the normal case), querying it just returns `"Auto"` and tells you
+nothing about the moment-to-moment state, so it can't drive a per-frame
+decision. The sunrise/sunset approach above doesn't have that problem.
+
+### Night-only timelapses (night mode)
+
+Set `capture.daylight_window.mode: night` (with the window `enabled`) to do the
+**opposite** of daylight capture — record only the **dark hours** and skip the
+day. It reuses the same sunrise/sunset math, just inverted; `buffer_minutes`
+trims that much twilight off each end of the night instead of extending it.
+
+Because a night spans midnight, night mode buckets frames by a **noon-to-noon
+day**, so one evening plus the following morning become **one continuous video**
+(labeled by the night's start date) instead of two half-clips split at midnight.
+And since a night isn't finished until dawn, the nightly timer can't build it —
+the **capture service builds each night automatically ~5 minutes after its
+window closes at sunrise**. (A manual build still works:
+`build_timelapse.py daily --date YYYY-MM-DD`.)
+
+Night mode needs a location set (`events.zip` or `latitude`/`longitude`), same
+as the daylight window. Leave `yearly.video_window` empty when using it — a
+daylight-hours filter makes no sense for night frames.
+
+### Per-camera schedules
+
+Everything above can be set **per camera**, so one camera can watch the dark
+hours while the rest shoot daylight — a yard camera logging which animals visit
+overnight, or one framing a moonrise, without changing what the others do:
+
+```yaml
+cameras:
+  - name: wildlife
+    # ...host, credentials, etc...
+    interval_seconds: 300     # optional; falls back to capture.interval_seconds
+    daylight_window:
+      enabled: true
+      mode: night
+      buffer_minutes: 30
+```
+
+Each key falls back to the global `capture.daylight_window` **independently**,
+so `mode: night` alone inherits the global buffer. The two are resolved
+separately, so a camera can enable its own window while the global one is off —
+or set `enabled: false` to opt out while the global one is on.
+
+A night camera builds its own video at **its** dawn, scoped to just that camera;
+the others build on the normal nightly timer. All of this is editable from the
+Config page under each camera's **Capture schedule**.
+
+Note that covering the dark hours roughly **doubles** how long that camera is
+capturing versus daylight-only. `interval_seconds` on the camera is the simplest
+way to hold disk use flat — a night camera at 300s writes a fifth as many frames
+per hour as one at 60s. See
+[Storage estimates](Storage-and-Performance#storage-estimates).
+
+### Cameras that sit out events
+
+Not every camera can see the weather. One pointed indoors, at a doorway, or
+framed tight on a walkway gains nothing from a storm — the burst frames are just
+disk, and the event clip is a video of nothing happening. Set `events_enabled:
+false` and that camera ignores events entirely:
+
+```yaml
+cameras:
+  - name: front-door
+    # ...host, credentials, etc...
+    events_enabled: false     # default true; omit to participate normally
+```
+
+Two things change for that camera, and nothing else does:
+
+- **No burst capture.** It holds its own `interval_seconds` through a storm
+  instead of dropping to `events.burst_interval_seconds`. The other cameras
+  still burst — the interval is resolved per camera.
+- **No event videos.** The events build skips it, so it produces no
+  `<date>_<tag>.mp4` clips. Its daily and yearly videos are unaffected.
+
+Its frames are **still tagged** either way. The tag is metadata embedded in each
+JPEG, it costs nothing, and keeping it means the frame record stays complete for
+searching and filtering later — it's the capture rate and the video build that
+opt out, not the metadata.
+
+Event clips built *before* you turned this off stay on disk and keep expiring on
+the normal `events_video.retention_days` schedule — turning this off stops new
+clips, it doesn't delete old ones. (Rebuilding one of those past dates with
+`build_timelapse.py events --date ...` does drop that camera's clips for that
+date from the Events list, since the rebuild replaces the whole day's entries.)
+
+Editable from the Config page under each camera's **Weather events**.

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -22,8 +22,9 @@
   other unauthenticated route here.
 - **Optional Config-page passcode.** You can put a single passcode (no
   username) in front of the Config page and its write/scan endpoints
-  (`/api/config`, `/api/discover`, `/api/discover/identify`, `/api/restart`)
-  while video browsing stays open for casual LAN viewing. It's **opt-in**:
+  (`/api/config`, `/api/discover`, `/api/discover/identify`, `/api/restart`,
+  `DELETE /api/videos/...`) while video browsing stays open for casual LAN
+  viewing. It's **opt-in**:
   set it from the Config page itself under **Config page access** (or remove
   it there later). Details:
   - The passcode is stored only as a **salted scrypt hash** in `config.yaml`
@@ -38,6 +39,10 @@
   - There's a modest failed-login throttle. This is a convenience gate for a
     trusted LAN, **not** a substitute for the VPN/reverse-proxy guidance
     above — the cookie rides over plain HTTP since ReoLapse serves no TLS.
+- **Deleting a video is gated the same way.** With no passcode set, anyone
+  on the LAN can delete a video from the player — but that's the same
+  exposure as being able to rewrite `config.yaml` and restart services,
+  which they already have on an open install.
 - Credentials live in `.env` (gitignored), never in `config.yaml`.
 - Prefer a **dedicated, least-privilege** camera/NVR account for ReoLapse. The
   Snap API passes credentials as URL parameters, so avoid `&`, `#`, `%` in that

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -1,0 +1,46 @@
+# Security
+
+- **There is no authentication.** The web UI has no login, no access control,
+  nothing — anyone who can reach port 8080 can browse and download every
+  video. **ReoLapse is a private, LAN-only tool. Do not port-forward it or
+  otherwise expose it to the internet.** If you need remote access, put it on
+  a VPN (Tailscale, WireGuard) or behind a reverse proxy that adds its own
+  auth and TLS — don't rely on ReoLapse itself for either. This was a
+  deliberate design choice, not an oversight: ReoLapse was built to run on
+  your home network, so authentication was not a priority for MVP release.
+  It may get added later if there's enough demand — open an issue if that's
+  you.
+- **The Config page can write `config.yaml` and scan your network — the
+  no-auth warning above applies doubly to it.** Anyone who can reach the app
+  can reconfigure your cameras or trigger a network scan; on an open install
+  the LAN-only posture is what protects this, not anything in the app itself.
+  The write endpoint does reject literal passwords (only `${VAR}` references
+  are accepted) and validates structure before touching the file, and its
+  `Content-Type: application/json` requirement means a plain cross-origin
+  `<form>` POST from some other site can't trigger it — but a malicious page
+  making a same-network JSON `fetch()` still could, same as it could hit any
+  other unauthenticated route here.
+- **Optional Config-page passcode.** You can put a single passcode (no
+  username) in front of the Config page and its write/scan endpoints
+  (`/api/config`, `/api/discover`, `/api/discover/identify`, `/api/restart`)
+  while video browsing stays open for casual LAN viewing. It's **opt-in**:
+  set it from the Config page itself under **Config page access** (or remove
+  it there later). Details:
+  - The passcode is stored only as a **salted scrypt hash** in `config.yaml`
+    (`webapp.config_passcode_hash`) — never in the clear, and never sent to
+    the browser. A hash is safe to keep there because, unlike a camera
+    password, it never needs to be reversed.
+  - A successful login sets an `HttpOnly`, `SameSite=Lax` session cookie
+    (server-side token, 12-hour expiry). `SameSite=Lax` keeps the cookie off
+    cross-site POST/`fetch`, so a malicious off-origin page can't ride your
+    session to the write endpoints. Restarting the web service or changing
+    the passcode logs every session out.
+  - There's a modest failed-login throttle. This is a convenience gate for a
+    trusted LAN, **not** a substitute for the VPN/reverse-proxy guidance
+    above — the cookie rides over plain HTTP since ReoLapse serves no TLS.
+- Credentials live in `.env` (gitignored), never in `config.yaml`.
+- Prefer a **dedicated, least-privilege** camera/NVR account for ReoLapse. The
+  Snap API passes credentials as URL parameters, so avoid `&`, `#`, `%` in that
+  password.
+- The bundled Flask server is a dev-grade WSGI server — fine for a trusted
+  LAN, not a hardened production server.

--- a/wiki/Storage-and-Performance.md
+++ b/wiki/Storage-and-Performance.md
@@ -62,6 +62,32 @@ This recalculates after every nightly build, so it tracks reality as your
 retention settings, camera count, or event frequency change — no manual math
 required.
 
+### Deleting a video by hand
+
+A **delete** button sits next to **download** in the player, for clearing out
+a junk video (camera glare, a false storm trigger) the moment you spot it
+instead of waiting on retention settings to catch it. What deleting each
+video type actually costs differs, and the confirmation dialog states the
+real rule rather than a generic warning:
+
+- **Yearly videos are always rebuildable** — `build_timelapse.py yearly
+  --year YYYY --force` regenerates one any time, since the frame archive it's
+  built from is never pruned.
+- **Daily and event videos are only rebuildable while their source frames
+  still exist** — `build_timelapse.py daily --date YYYY-MM-DD --camera X` (or
+  `events` for an event clip), which only works within
+  `storage.keep_snapshots_days` of that day. Past that window, deletion is
+  permanent.
+
+Deleting an event clip also drops its `events.jsonl` index entry immediately,
+rather than waiting for the next nightly build to notice the file is gone.
+Deleting any video does **not** free the snapshot frames it was built from —
+those are governed by their own retention (`storage.keep_snapshots_days`),
+independent of what videos exist.
+
+This is a write/delete action, so it's gated by the Config-page passcode when
+one is set — see [Security](Security).
+
 ## Performance
 
 Reference deployment: a Proxmox VM with **1 vCPU and 1 GB RAM** (Ubuntu 26.04

--- a/wiki/Storage-and-Performance.md
+++ b/wiki/Storage-and-Performance.md
@@ -1,0 +1,90 @@
+# Storage & Performance
+
+## Storage estimates
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/SeriesOfTubez/reolapse/main/assets/screenshot-storage.png" width="820" alt="ReoLapse Storage tab: stat cards for disk used, snapshots, daily and yearly video sizes and average build time; a storage runway forecast banner; and a per-camera usage table">
+</p>
+
+The **Storage** tab in the web UI shows live per-camera and system-wide usage
+and daily growth (`storage_stats.py`, refreshed after every nightly build —
+no guessing required once it's running). Before you get there, here's real
+data from the reference deployment (3 Reolink cameras of different
+resolutions, 1 frame/minute, all-day capture) to help you size disk up front:
+
+| Camera | Resolution | Avg JPEG size | Raw snapshots/day | Daily video/day |
+|---|---|---|---|---|
+| Reolink Wired WiFi Doorbell | 2560×1920 (4.9 MP) | ~450 KB | ~0.6 GB | ~200 MB |
+| Reolink TrackMix WiFi (Wide Cam) | 3840×2160 (8.3 MP) | ~1.3 MB | ~1.8 GB | ~290 MB |
+| Reolink OMVI 3i WiFi (Fixed Cam) | 5120×1920 (9.8 MP) | ~1.7 MB | ~2.4 GB | ~470 MB |
+
+Rough rule of thumb: **~0.1–0.2 MB per megapixel per frame**, varying with
+scene complexity and each camera's own JPEG quality setting — the range above
+spans 3 real cameras and isn't a tight line, so treat it as a ballpark, not a
+formula. For a precise number, check the actual size of a few files in
+`data/snapshots/<camera>/` and multiply by how many frames/day you'll capture
+(`86400 / capture.interval_seconds`, or less if `start_time`/`end_time` is set).
+
+What accumulates and what doesn't, and how to bound each:
+
+- **Raw snapshots** are a *rolling window* — pruned `storage.keep_snapshots_days`
+  after each day's video builds, so this cost is already bounded by default.
+- **Daily videos, yearly videos, and event clips default to forever** (`0` in
+  `daily_video.retention_days`, `yearly.retention_years`,
+  `events_video.retention_days`) but each is independently configurable. In
+  the reference 3-camera deployment, daily videos alone grow by **~0.9
+  GB/day** — roughly **28 GB/month** or **340 GB/year** — unbounded by
+  default, before adding storm/snow clips or a fourth camera.
+- **Yearly *archive frames* (`data/yearly_frames/`) are never prunable, by
+  design** — that's the permanent, irreplaceable source the yearly video is
+  built from. This is why pruning a *yearly video* is cheap and safe: its
+  frames are untouched, so `build_timelapse.py yearly --year YYYY`
+  regenerates it any time. The frame archive itself is small regardless
+  (well under 100 MB/day across 3 cameras) — it's not what threatens your disk.
+
+### Retention & the storage forecast
+
+The Storage tab shows your **current retention settings** for all four tiers
+side by side, plus a **forecast**: it computes the eventual steady-state size
+of every tier that has a retention limit set, and a growth rate for whatever
+doesn't (the yearly archive frames always contribute here, since they can't
+be bounded). From that it reports one of three verdicts against your current
+free disk space:
+
+- **Runway** — some tier still grows forever; shows how long until disk
+  fills at the current rate (e.g. "~20 days").
+- **Headroom** — every tier is bounded and there's room to spare once each
+  reaches its ceiling.
+- **Shortage** — the bounded tiers' ceilings alone already exceed your free
+  space, before any unbounded growth is even considered.
+
+This recalculates after every nightly build, so it tracks reality as your
+retention settings, camera count, or event frequency change — no manual math
+required.
+
+## Performance
+
+Reference deployment: a Proxmox VM with **1 vCPU and 1 GB RAM** (Ubuntu 26.04
+cloud image), on a Proxmox host with an **Intel N95**. With 3 cameras and a
+full day of frames (~1440/camera), the nightly build takes about **45–50
+minutes** total and peaks around **700 MB RAM**. Encoding (`libx264`, default
+preset `medium`) is the bottleneck; the hardlink/copy staging step is
+comparatively instant.
+
+Cameras currently build **sequentially, one at a time** (not in parallel), so
+total build time is roughly the sum of each camera's encode time. Within a
+single camera's encode, though, `libx264` threads automatically across
+whatever cores are available — so **more vCPUs should speed up each camera's
+build** (diminishing returns past ~8 threads), and a faster single-thread CPU
+shortens it further. Neither has been benchmarked beyond the reference
+1-vCPU deployment above; reports from other hardware are welcome.
+
+If build time is a problem before you can add cores: lower `daily_video.max_height`
+(fewer pixels to encode), `capture.interval_seconds` (fewer frames/day), or
+the `preset` for the video type you're building (`daily_video.preset`,
+`yearly.preset`, `events_video.preset` — faster x264 presets trade a larger
+file for less CPU time). All are editable from the Config page.
+
+The Storage tab tracks your **own** build times (an "avg build time" card,
+averaged over the last 60 nightly builds) — that's the number to trust for
+your actual hardware and camera count, not the reference figures above.

--- a/wiki/Weather-and-Storm-Detection.md
+++ b/wiki/Weather-and-Storm-Detection.md
@@ -17,6 +17,38 @@ which has no lightning to protect. If weather tagging is enabled without a
 resolvable location, storm/snow tagging is skipped and the web UI shows a
 warning banner.
 
+## Event frames in the daily video
+
+While a storm or snow burst is active, capture drops to
+`events.burst_interval_seconds`, and those minutes land in the same
+`data/snapshots/<camera>/<date>/` folder as everything else — so a storm hour
+is far denser than the rest of the day, and the daily video crawls through it
+at a fraction of its normal pace.
+
+`daily_video.include_events` (default `false`) excludes frames captured
+inside an active burst span from the daily `.mp4` **only**. The event clip on
+the Events tab, the yearly video's frame archive, and the frames on disk are
+all untouched — this setting affects nothing but which frames make it into
+that one video. Exclusion is driven by `events.burst_tags` specifically (not
+`events_video.tags`, which is a separate, independent list of what gets its
+own clip and can legitimately include non-burst tags like moon phases), and
+spans are reconstructed from `data/conditions/<date>.jsonl` with the same
+20-minute gap merge the event clips use — so a frame is excluded from the
+daily video exactly when it's inside the span that produced an event clip,
+never more or less. It's skipped entirely for `events_enabled: false`
+cameras: they never burst, so during a site-wide storm their frames are
+ordinary cadence frames, and excluding them would gouge a hole in an
+unaffected camera's day.
+
+Any camera can override the global setting with `include_events_in_daily` —
+see the [Configuration Reference](Configuration-Reference). If a day ends up
+almost entirely inside a burst span, the daily video for that day is skipped
+rather than rendered nearly empty (the yearly archive still gets that day's
+frames regardless). Changed your mind after the fact? Rebuild it with
+`build_timelapse.py daily --date YYYY-MM-DD --camera X` — that only works
+while the day's snapshot frames still exist, i.e. within
+`storage.keep_snapshots_days`.
+
 ## How a storm is detected
 
 Weather services report "thunderstorm" far less often than thunderstorms

--- a/wiki/Weather-and-Storm-Detection.md
+++ b/wiki/Weather-and-Storm-Detection.md
@@ -1,0 +1,57 @@
+# Weather & Storm Detection
+
+`events.weather_enabled` and `events.lunar_enabled` are independent
+switches — turn on either, both, or neither.
+
+With `events.weather_enabled: true` and a location set (`events.zip`, or
+`latitude`/`longitude`), capture polls NWS + Open-Meteo every `poll_minutes`
+for storm/snow/rain conditions. Active tags are appended to
+`data/conditions/<date>.jsonl` and embedded in each frame as a JPEG comment
+(`{"tags":["storm"]}`, visible in exiftool). Storms/snow trigger burst
+capture, and the nightly build renders a clip per event span into the
+**Events** tab. Deflicker for these clips is off by default (it would smooth
+away lightning flashes) but is fully configurable — see
+`events_video.deflicker_size` / `deflicker_by_tag` in the
+[Configuration Reference](Configuration-Reference) if you'd like it on for snow,
+which has no lightning to protect. If weather tagging is enabled without a
+resolvable location, storm/snow tagging is skipped and the web UI shows a
+warning banner.
+
+## How a storm is detected
+
+Weather services report "thunderstorm" far less often than thunderstorms
+happen. Open-Meteo's `weather_code` only returns the thunderstorm values
+(WMO 95/96/99) in a minority of actual storms — a storm downpour normally comes
+back as *rain showers* instead. Detecting storms from that code alone means the
+`storm` tag almost never fires, so no burst capture and no event clips. A real
+deployment ran 19 days through repeated storms and logged **zero** storm tags
+for exactly this reason.
+
+So `storm` is corroborated from four independent signals, any one of which is
+enough:
+
+| signal | source | why |
+|---|---|---|
+| An active severe alert | NWS alerts (US) | officially warned events |
+| Observed thunderstorm | nearest NWS station (US) | what's actually happening now, not a forecast |
+| WMO code 95 / 96 / 99 | Open-Meteo | when the model does say thunderstorm |
+| Rain **plus** high CAPE | Open-Meteo | convective rain the code labels as showers |
+| Strong wind gusts | Open-Meteo | squall / gust front, wet or dry |
+
+CAPE (convective available potential energy) is *potential*, not occurrence — it
+can sit above 2000 J/kg under a clear sky — so it only ever tags a storm
+alongside actual falling rain. Tune the thresholds with `events.storm_cape_min`,
+`storm_precip_mm`, and `storm_gust_kmh`, or from the Config page under
+**Storm detection tuning**.
+
+Replayed against 92 days of real hourly weather, this raised storm detection
+from 5 days to 17, with 5 dry-hour triggers out of 1588 (all of them genuine
+gust fronts).
+
+## Surviving API outages
+
+These free services hand out timeouts and 502/503s fairly regularly. A failed
+poll tells you nothing about the weather, so ReoLapse holds a source's last
+known tags for `events.stale_grace_minutes` (default: three polls) instead of
+reading the outage as *all clear*. Without this, one timed-out request in the
+middle of a storm ends the burst early and truncates the event clip.


### PR DESCRIPTION
## Summary
Today, cutting a release is four disconnected manual steps, and the wiki has zero connection to versioning at all — it's edited on its own schedule with no record of whether a push to the live wiki ever happened. This makes a release a single bundled action instead.

- Wiki pages now live in `wiki/` in this repo (imported verbatim from the live wiki as the first commit — `diff -r wiki/ <live wiki clone>` was empty). **Edit them here in a PR, not in the browser** — the release workflow mirrors this folder onto the GitHub wiki on every tag push, so a browser edit gets overwritten by the next release.
- New `.github/workflows/release.yml`, triggered on `git push origin vX.Y.Z`:
  1. Verifies `VERSION` matches the tag and `CHANGELOG.md` has a non-empty `## [X.Y.Z]` section for it — fails loudly rather than publishing something wrong.
  2. Publishes a GitHub Release whose body is that CHANGELOG section verbatim (via new `scripts/changelog_section.py`).
  3. Mirrors `wiki/` onto the GitHub wiki.
- Uses the default `GITHUB_TOKEN` with `contents: write` — no PAT/secret needed for a repo pushing to its own wiki (confirmed against current GitHub Actions documentation and community precedent). If that turns out wrong on the first real tag, the fallback is a one-line change (a fine-grained PAT as a repo secret).
- Wiki content for the two features that just merged (video deletion, optional daily-video event frames) is included.

## Test plan
- [x] `scripts/changelog_section.py` tested against the real CHANGELOG.md: correct extraction, `v`-prefix tolerance, correct failure on a missing/empty section
- [x] Wiki import verified byte-identical to the live wiki at import time
- [ ] The actual tag-triggered run (release creation + wiki push) is unverified until a real tag — that's the next PR after this one
- [x] Semgrep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)