### PR TITLE
Event clip duration/merging: pad short clips, configurable merge gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,16 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   page under **Event video clips**; per-tag overrides are config-file only.
 
 ### Changed
-- **`events_video.min_frames` is renamed to `events_video.min_seconds`.**
-  The minimum-clip-length setting is a duration; a key literally named
-  `min_frames` that actually meant "roughly one second per unit" was
-  misleading. `min_seconds` (default `5`) is converted to a frame count via
-  `events_video.fps` at build time. Existing configs keep working unchanged —
+- **`events_video.min_frames` is renamed to `events_video.min_seconds`, and
+  now pads short clips instead of dropping them.** The minimum-clip-length
+  setting is a duration; a key literally named `min_frames` that actually
+  meant "roughly one second per unit" was misleading. `min_seconds` (default
+  `5`) is converted to a frame count via `events_video.fps` at build time.
+  Every tagged span gets a clip now, even a brief one — a span shorter than
+  the minimum is padded out with extra frames from before/after the event
+  instead of being skipped, so a real but short-lived storm alert still gets
+  a watchable clip rather than silently producing nothing. Existing configs
+  keep working unchanged —
   `min_frames` is still honored if `min_seconds` is absent, so a config.yaml
   that already sets `min_frames: 30` keeps its old ~1-second floor forever
   unless you act. To adopt the new 5-second default, replace `min_frames: 30`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,36 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   gone. `/videos/<camera>/<vtype>/<name>` (the unauthenticated browse route)
   now validates the camera name too, closing a gap where only `name` and
   `vtype` were checked. Existing configs are unaffected.
+- **Configurable merge gap for event clips.** Two spans of the same tag close
+  together used to always merge into one clip after a fixed 20-minute gap.
+  That gap is now `events_video.gap_minutes` (still defaults to 20), with an
+  optional `gap_minutes_by_tag` override for individual tags — a slower-moving
+  snow event can tolerate a longer lull than a storm before it's split into a
+  separate clip. The event-clip builder and the daily video's event-frame
+  exclusion filter (`daily_video.include_events`) both reconstruct spans
+  through the same resolver, so they always agree on where one event ends and
+  the next begins, regardless of which one changes. Editable from the Config
+  page under **Event video clips**; per-tag overrides are config-file only.
+
+### Changed
+- **`events_video.min_frames` is renamed to `events_video.min_seconds`.**
+  The minimum-clip-length setting is a duration; a key literally named
+  `min_frames` that actually meant "roughly one second per unit" was
+  misleading. `min_seconds` (default `5`) is converted to a frame count via
+  `events_video.fps` at build time. Existing configs keep working unchanged —
+  `min_frames` is still honored if `min_seconds` is absent, so a config.yaml
+  that already sets `min_frames: 30` keeps its old ~1-second floor forever
+  unless you act. To adopt the new 5-second default, replace `min_frames: 30`
+  with `min_seconds: 5` in config.yaml, or just open the Config page, which
+  migrates it for you automatically the moment you view **Event video clips**.
+
+### Fixed
+- **An event still active at midnight produced zero frames and no clip.**
+  `tag_spans()` closed a still-open span at end-of-day using a bound that
+  formatted as `"000000"`, which a string comparison against frame timestamps
+  can never match. Late-running storms/snow events now close at `23:59:59`
+  instead, so they get the clip (and, post event-frame-in-daily-video, the
+  correct daily-video exclusion) they should have all along.
 
 ## [0.3.0] - 2026-08-08
 

--- a/build_timelapse.py
+++ b/build_timelapse.py
@@ -522,6 +522,41 @@ def frames_outside_spans(cfg, date, frames, tags):
             if not any(lo <= f.stem <= hi for lo, hi in windows)]
 
 
+def pad_to_min_frames(all_frames, start_hhmmss, end_hhmmss, min_frames):
+    """Frames for a tagged span, padded outward (alternating before/after) to
+    at least `min_frames` when the span itself is shorter than that.
+
+    Every triggered event gets a clip at least `min_frames` long instead of
+    being skipped for being brief — padding is pulled from the rest of the
+    camera's day and never crosses the day's boundary. If the whole day
+    doesn't have `min_frames` frames, returns everything available rather
+    than padding forever. Returns [] only when the span itself matched no
+    frames at all (e.g. the camera was offline for the whole event) — there's
+    nothing to anchor a clip on in that case.
+    """
+    indices = [i for i, f in enumerate(all_frames) if start_hhmmss <= f.stem <= end_hhmmss]
+    if not indices:
+        return []
+    lo, hi = indices[0], indices[-1]
+    deficit = min_frames - (hi - lo + 1)
+    grow_low = True
+    while deficit > 0 and (lo > 0 or hi < len(all_frames) - 1):
+        if grow_low and lo > 0:
+            lo -= 1
+            deficit -= 1
+        elif not grow_low and hi < len(all_frames) - 1:
+            hi += 1
+            deficit -= 1
+        elif lo > 0:
+            lo -= 1
+            deficit -= 1
+        elif hi < len(all_frames) - 1:
+            hi += 1
+            deficit -= 1
+        grow_low = not grow_low
+    return all_frames[lo:hi + 1]
+
+
 def build_event_videos(cfg, date, camera=None):
     ev = cfg.get("events_video") or {}
     tags = ev.get("tags") or []
@@ -547,9 +582,9 @@ def build_event_videos(cfg, date, camera=None):
         all_frames = day_frames(cfg, cam["name"], date)
         for tag in tags:
             for i, (start, end) in enumerate(tag_spans(cfg, date, tag)):
-                frames = [f for f in all_frames
-                          if start.strftime("%H%M%S") <= f.stem <= end.strftime("%H%M%S")]
-                if len(frames) < min_frames:
+                frames = pad_to_min_frames(
+                    all_frames, start.strftime("%H%M%S"), end.strftime("%H%M%S"), min_frames)
+                if not frames:
                     continue
                 suffix = f"-{i + 1}" if i else ""
                 out = (videos_dir(cfg) / cam["name"] / "events"

--- a/build_timelapse.py
+++ b/build_timelapse.py
@@ -26,8 +26,9 @@ from pathlib import Path
 
 from common import (build_status_path, camera_events_enabled,
                     camera_include_events_in_daily, camera_interval_seconds,
-                    load_config, local_today, snapshots_dir, tzinfo_for,
-                    videos_dir, yearly_frames_dir)
+                    event_gap_minutes, event_min_frames, load_config,
+                    local_today, snapshots_dir, tzinfo_for, videos_dir,
+                    yearly_frames_dir)
 
 log = logging.getLogger("timelapse")
 
@@ -423,12 +424,20 @@ def sync_events_index(cfg):
     return dropped
 
 
-def tag_spans(cfg, date, tag, gap_minutes=20):
+def tag_spans(cfg, date, tag, gap_minutes=None):
     """Reconstruct when a tag was active on a date from the conditions log.
 
     The log records tag-set *changes*, so state at midnight is seeded from
     the last entry of the previous day's file.
+
+    `gap_minutes` resolves itself (via common.event_gap_minutes) when not
+    given explicitly, so both callers — build_event_videos and (post
+    daily-video-event-frames) frames_outside_spans — agree per tag without
+    either needing to remember to pass it. The explicit parameter stays for
+    one-off overrides and manual testing.
     """
+    if gap_minutes is None:
+        gap_minutes = event_gap_minutes(cfg, tag)
     cond_dir = cfg["storage"]["root"] / "conditions"
 
     def entries(day):
@@ -518,7 +527,7 @@ def build_event_videos(cfg, date, camera=None):
     tags = ev.get("tags") or []
     if not tags:
         return
-    min_frames = ev.get("min_frames", 30)
+    min_frames = event_min_frames(cfg)
     index_path = cfg["storage"]["root"] / "events.jsonl"
 
     # Drop stale index entries for this date before re-adding (rebuild-safe)

--- a/build_timelapse.py
+++ b/build_timelapse.py
@@ -439,7 +439,6 @@ def tag_spans(cfg, date, tag, gap_minutes=20):
                 if line.strip()]
 
     day_start = dt.datetime.combine(date, dt.time.min)
-    day_end = day_start + dt.timedelta(days=1)
 
     active_since = None
     prev = entries(date - dt.timedelta(days=1))
@@ -456,7 +455,12 @@ def tag_spans(cfg, date, tag, gap_minutes=20):
             spans.append((active_since, ts))
             active_since = None
     if active_since is not None:
-        spans.append((active_since, day_end))
+        # A span still active at the end of the log gets closed at 23:59:59
+        # rather than midnight ("000000") — the frame filter below is a
+        # string comparison of HHMMSS stems, so a "000000" upper bound can
+        # never match any frame and an event still running at midnight would
+        # otherwise produce zero frames and no clip.
+        spans.append((active_since, dt.datetime.combine(date, dt.time.max)))
 
     merged = []
     for start, end in spans:

--- a/common.py
+++ b/common.py
@@ -183,10 +183,12 @@ DEFAULT_EVENT_GAP_MINUTES = 20
 
 
 def event_min_frames(cfg) -> int:
-    """Minimum frames an event span needs before a clip is rendered, resolved
-    from events_video.min_seconds x events_video.fps. min_frames is the
-    pre-0.4 key and still wins if min_seconds is absent, so an existing
-    config.yaml keeps behaving exactly as it did.
+    """Floor an event clip gets padded up to, resolved from
+    events_video.min_seconds x events_video.fps. Every tagged span still gets
+    a clip — a short one is padded with extra frames from around the event,
+    never skipped for being brief. min_frames is the pre-0.4 key and still
+    wins if min_seconds is absent, so an existing config.yaml keeps behaving
+    exactly as it did.
     """
     ev = cfg.get("events_video") or {}
     fps = ev.get("fps", 30)

--- a/common.py
+++ b/common.py
@@ -7,6 +7,7 @@ systemd values win). See config.example.yaml and .env.example.
 """
 
 import json
+import math
 import os
 import re
 import time
@@ -175,6 +176,64 @@ def camera_include_events_in_daily(cfg, cam) -> bool:
     if value is None:
         value = (cfg.get("daily_video") or {}).get("include_events")
     return bool(value)
+
+
+DEFAULT_EVENT_MIN_SECONDS = 5
+DEFAULT_EVENT_GAP_MINUTES = 20
+
+
+def event_min_frames(cfg) -> int:
+    """Minimum frames an event span needs before a clip is rendered, resolved
+    from events_video.min_seconds x events_video.fps. min_frames is the
+    pre-0.4 key and still wins if min_seconds is absent, so an existing
+    config.yaml keeps behaving exactly as it did.
+    """
+    ev = cfg.get("events_video") or {}
+    fps = ev.get("fps", 30)
+    try:
+        fps = float(fps)
+    except (TypeError, ValueError):
+        fps = 30.0
+    fps = max(1.0, fps)
+
+    min_seconds = ev.get("min_seconds")
+    if min_seconds is not None:
+        try:
+            frames = math.ceil(float(min_seconds) * fps)
+        except (TypeError, ValueError):
+            frames = math.ceil(DEFAULT_EVENT_MIN_SECONDS * fps)
+        return max(1, frames)
+
+    min_frames = ev.get("min_frames")
+    if min_frames is not None:
+        try:
+            return max(1, int(min_frames))
+        except (TypeError, ValueError):
+            pass
+
+    return max(1, math.ceil(DEFAULT_EVENT_MIN_SECONDS * fps))
+
+
+def event_gap_minutes(cfg, tag) -> float:
+    """Minutes of quiet that still count as one event for `tag`.
+
+    Both the event-clip builder and the daily-video exclusion filter
+    reconstruct spans through tag_spans, so they must agree per tag or a
+    frame can be excluded from the daily video without a clip existing (or
+    vice versa). Resolving here, once, is what makes that structural.
+    """
+    ev = cfg.get("events_video") or {}
+    by_tag = ev.get("gap_minutes_by_tag") or {}
+
+    value = by_tag.get(tag) if isinstance(by_tag, dict) else None
+    if value is None:
+        value = ev.get("gap_minutes")
+
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return float(DEFAULT_EVENT_GAP_MINUTES)
+    return max(0.0, value)
 
 
 def build_status_path(cfg) -> Path:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -254,7 +254,21 @@ events:
 
 events_video:
   tags: [storm, snow]         # render a clip per active span of these tags
-  min_frames: 30
+  min_seconds: 5               # a tagged span shorter than this doesn't get a
+                              # clip — filters out brief blips. Translated to
+                              # a frame count via fps below. The pre-0.4 key
+                              # `min_frames` is still honored if this is
+                              # absent, so an existing config.yaml keeps
+                              # behaving exactly as it did; the Config page
+                              # migrates min_frames -> min_seconds for you.
+  gap_minutes: 20              # two spans of the same tag closer together
+                              # than this render as one clip instead of two.
+                              # Also decides which frames the daily video
+                              # excludes when daily_video.include_events is
+                              # off, so the two always agree.
+  # gap_minutes_by_tag:       # per-tag override — e.g. a slower-moving snow
+  #   snow: 45                # event can tolerate a longer lull than a storm
+  #   storm: 15                # before it's treated as a separate event
   fps: 30
   crf: 20
   preset: medium               # see daily_video.preset above

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -254,13 +254,15 @@ events:
 
 events_video:
   tags: [storm, snow]         # render a clip per active span of these tags
-  min_seconds: 5               # a tagged span shorter than this doesn't get a
-                              # clip — filters out brief blips. Translated to
-                              # a frame count via fps below. The pre-0.4 key
-                              # `min_frames` is still honored if this is
-                              # absent, so an existing config.yaml keeps
-                              # behaving exactly as it did; the Config page
-                              # migrates min_frames -> min_seconds for you.
+  min_seconds: 5               # every tagged span gets a clip, even a brief
+                              # one — but a span shorter than this gets padded
+                              # with extra frames from around the event so the
+                              # clip is never just a couple of frames long.
+                              # Translated to a frame count via fps below. The
+                              # pre-0.4 key `min_frames` is still honored if
+                              # this is absent, so an existing config.yaml
+                              # keeps behaving exactly as it did; the Config
+                              # page migrates min_frames -> min_seconds for you.
   gap_minutes: 20              # two spans of the same tag closer together
                               # than this render as one clip instead of two.
                               # Also decides which frames the daily video

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -254,6 +254,30 @@ def validate_config(cfg):
         elif val < 0:
             problems.append(f"events.{key} must not be negative")
 
+    # events_video: only the new/changed keys — adding checks for pre-existing
+    # fps/crf/preset would be scope creep, a behaviour change unrelated to
+    # this feature.
+    evcfg = cfg.get("events_video") or {}
+    for key in ("min_seconds", "min_frames", "gap_minutes"):
+        val = evcfg.get(key)
+        if val is None:
+            continue
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            problems.append(f"events_video.{key} must be a number")
+        elif val < 0:
+            problems.append(f"events_video.{key} must not be negative")
+
+    gap_by_tag = evcfg.get("gap_minutes_by_tag")
+    if gap_by_tag is not None:
+        if not isinstance(gap_by_tag, dict):
+            problems.append("events_video.gap_minutes_by_tag must be a mapping")
+        else:
+            for tag, val in gap_by_tag.items():
+                if isinstance(val, bool) or not isinstance(val, (int, float)):
+                    problems.append(f"events_video.gap_minutes_by_tag[{tag!r}] must be a number")
+                elif val < 0:
+                    problems.append(f"events_video.gap_minutes_by_tag[{tag!r}] must not be negative")
+
     # The Forecast tab's window. Open-Meteo serves 10 days and no more, so a
     # larger number would silently be clamped rather than do what was asked.
     days = (cfg.get("events") or {}).get("forecast_days")

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -2235,9 +2235,10 @@ function buildEventsVideoSection() {
     cfgDelete("events_video.min_frames");
   }
   sec.appendChild(fieldRow("Minimum clip length (seconds)",
-    "Skips rendering a clip for a tagged span shorter than this many seconds — filters out brief blips "
-    + "(e.g. a storm alert that clears in a couple of minutes) that wouldn't make a meaningful clip. "
-    + "Converted to a frame count using Frame rate (fps) below.",
+    "Every tagged span still gets a clip, even a brief one (e.g. a storm alert that clears in a couple of "
+    + "minutes) — but a clip shorter than this gets padded out with extra frames from before/after the event "
+    + "so it's never just a blink-and-you-miss-it couple of frames. Converted to a frame count using Frame "
+    + "rate (fps) below.",
     numberField("events_video.min_seconds", {default: 5, min: 0, step: "0.5"})));
   sec.appendChild(fieldRow("Merge gap (minutes)",
     "Two spans of the same tag separated by less than this are rendered as one clip instead of two — a "

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -1198,6 +1198,19 @@ function cfgSet(path, value) {
   obj[parts[parts.length - 1]] = value;
 }
 
+// Removes a key entirely (vs. cfgSet(path, null), which would leave a dead
+// "key: null" line in the saved config.yaml) — used by migrations that
+// rename a key, so the old one doesn't linger.
+function cfgDelete(path) {
+  const parts = path.split(".");
+  let obj = state.configData;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (obj[parts[i]] == null || typeof obj[parts[i]] !== "object") return;
+    obj = obj[parts[i]];
+  }
+  delete obj[parts[parts.length - 1]];
+}
+
 function fieldRow(labelText, hintText, inputEl, colLayout) {
   const row = document.createElement("div");
   row.className = "cfg-row" + (colLayout ? " cfg-row-col" : "");
@@ -2208,10 +2221,32 @@ function buildEventsVideoSection() {
     + "— e.g. a dedicated video for each storm. Any tag works here, including moon phases and seasons, not "
     + "just weather.",
     tagCheckGroup("events_video.tags", EVENT_TAGS), true));
-  sec.appendChild(fieldRow("Minimum frames", "Skips rendering a clip for a tagged span shorter than this many "
-    + "frames — filters out brief blips (e.g. a storm alert that clears in a couple of minutes) that wouldn't "
-    + "make a meaningful clip.",
-    numberField("events_video.min_frames", {default: 30})));
+  // min_frames -> min_seconds migration: a config.yaml written before this
+  // rename only has min_frames, which is still honored (see
+  // common.event_min_frames) but is invisible in this UI's own units. Same
+  // pattern as timezoneField()'s auto-migration and the location radios
+  // nulling out lat/lon — mutate state.configData in place at render time,
+  // before the user does anything, so what's on screen matches what a Save
+  // would actually write.
+  if (cfgGet("events_video.min_seconds", null) == null && cfgGet("events_video.min_frames", null) != null) {
+    const fps = cfgGet("events_video.fps", 30) || 30;
+    const minFrames = cfgGet("events_video.min_frames", 30);
+    cfgSet("events_video.min_seconds", Math.round((minFrames / fps) * 10) / 10);
+    cfgDelete("events_video.min_frames");
+  }
+  sec.appendChild(fieldRow("Minimum clip length (seconds)",
+    "Skips rendering a clip for a tagged span shorter than this many seconds — filters out brief blips "
+    + "(e.g. a storm alert that clears in a couple of minutes) that wouldn't make a meaningful clip. "
+    + "Converted to a frame count using Frame rate (fps) below.",
+    numberField("events_video.min_seconds", {default: 5, min: 0, step: "0.5"})));
+  sec.appendChild(fieldRow("Merge gap (minutes)",
+    "Two spans of the same tag separated by less than this are rendered as one clip instead of two — a "
+    + "storm that briefly drops below threshold and comes right back still gets a single continuous video. "
+    + "The same gap also decides which frames are held out of the daily video when Daily video > Include "
+    + "event frames is off, so the two always agree on where one event ends and the next begins. Per-tag "
+    + "overrides aren't editable in this UI — set events_video.gap_minutes_by_tag directly in config.yaml "
+    + "(a hand-set value there survives a save from this page untouched).",
+    numberField("events_video.gap_minutes", {default: 20, min: 0})));
   sec.appendChild(fieldRow("Frame rate (fps)", "Playback speed of event clips, in frames per second — same "
     + "idea as Daily video's Frame rate.", numberField("events_video.fps", {default: 30})));
   sec.appendChild(fieldRow("Quality (CRF)", "x264 quality for event clips — same scale as Daily video's "

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -28,7 +28,7 @@ not: reference them as `${VAR}` and put the values in `.env`. Highlights:
 | `events.lunar_enabled` | Moon-event tagging — no location required |
 | `events.season_enabled` | Spring/summer/fall/winter tagging on frames + video metadata — no location required |
 | `events_video.tags` | Which tags get their own `<date>_<tag>.mp4` clip (default `storm`, `snow`; any tag works, including moon events) |
-| `events_video.min_seconds` | Minimum length (seconds) a tagged span needs before it gets a clip (default `5`); converted to a frame count via `events_video.fps`. Pre-0.4 configs' `min_frames` is still honored if `min_seconds` is absent — see [Weather & Storm Detection](Weather-and-Storm-Detection) |
+| `events_video.min_seconds` | Floor a clip gets padded up to (default `5`); every tagged span gets a clip, but one shorter than this is padded with extra frames from around the event rather than skipped. Converted to a frame count via `events_video.fps`. Pre-0.4 configs' `min_frames` is still honored if `min_seconds` is absent — see [Weather & Storm Detection](Weather-and-Storm-Detection) |
 | `events_video.gap_minutes` / `gap_minutes_by_tag` | Minutes of quiet that still count as one event (default `20`); optional per-tag override. Shared with the daily video's event-frame exclusion filter, so both agree on where one event ends and the next begins |
 | `events_video.deflicker_size` / `deflicker_by_tag` | Deflicker for event clips — off by default (protects lightning in storm clips), overridable per tag (e.g. enable for `snow`) |
 | `events_video.retention_days` | Delete an event clip this many days after its date; `0` = forever |

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -28,6 +28,8 @@ not: reference them as `${VAR}` and put the values in `.env`. Highlights:
 | `events.lunar_enabled` | Moon-event tagging — no location required |
 | `events.season_enabled` | Spring/summer/fall/winter tagging on frames + video metadata — no location required |
 | `events_video.tags` | Which tags get their own `<date>_<tag>.mp4` clip (default `storm`, `snow`; any tag works, including moon events) |
+| `events_video.min_seconds` | Minimum length (seconds) a tagged span needs before it gets a clip (default `5`); converted to a frame count via `events_video.fps`. Pre-0.4 configs' `min_frames` is still honored if `min_seconds` is absent — see [Weather & Storm Detection](Weather-and-Storm-Detection) |
+| `events_video.gap_minutes` / `gap_minutes_by_tag` | Minutes of quiet that still count as one event (default `20`); optional per-tag override. Shared with the daily video's event-frame exclusion filter, so both agree on where one event ends and the next begins |
 | `events_video.deflicker_size` / `deflicker_by_tag` | Deflicker for event clips — off by default (protects lightning in storm clips), overridable per tag (e.g. enable for `snow`) |
 | `events_video.retention_days` | Delete an event clip this many days after its date; `0` = forever |
 | `webapp.accent_color` | UI accent color: `amber` (default), `green`, `blue`, `red`, `purple`, `yellow` |

--- a/wiki/Weather-and-Storm-Detection.md
+++ b/wiki/Weather-and-Storm-Detection.md
@@ -32,10 +32,11 @@ all untouched — this setting affects nothing but which frames make it into
 that one video. Exclusion is driven by `events.burst_tags` specifically (not
 `events_video.tags`, which is a separate, independent list of what gets its
 own clip and can legitimately include non-burst tags like moon phases), and
-spans are reconstructed from `data/conditions/<date>.jsonl` with the same
-20-minute gap merge the event clips use — so a frame is excluded from the
-daily video exactly when it's inside the span that produced an event clip,
-never more or less. It's skipped entirely for `events_enabled: false`
+spans are reconstructed from `data/conditions/<date>.jsonl` with the same,
+configurable gap merge (`events_video.gap_minutes`) the event clips use — so
+a frame is excluded from the daily video exactly when it's inside the span
+that produced an event clip, never more or less. It's skipped entirely for
+`events_enabled: false`
 cameras: they never burst, so during a site-wide storm their frames are
 ordinary cadence frames, and excluding them would gouge a hole in an
 unaffected camera's day.


### PR DESCRIPTION
## Summary
Two existing levers tuned, plus a real correctness bug fixed along the way.

- **Fixed:** an event still active at midnight produced zero frames and no clip — `tag_spans()` closed a still-open span using a bound that string-compared as `"000000"`, which can never match a frame's `HHMMSS` timestamp. Late-running storms/snow events now close at `23:59:59` instead.
- **Changed:** `events_video.min_frames` → `events_video.min_seconds` (default `5`), and **every tagged span now gets a clip** — one shorter than the minimum is padded with extra frames from before/after the event rather than silently dropped. `min_frames` is still honored as a fallback, so existing configs keep their old behavior until you act (or just open the Config page, which migrates it for you).
- **Added:** `events_video.gap_minutes` (default `20`, was hardcoded) with an optional `gap_minutes_by_tag` override, mirroring the existing `deflicker_by_tag` pattern. `tag_spans()` resolves it internally, so both the event-clip builder and the daily video's event-frame exclusion filter always agree on where one event ends and the next begins.

## Test plan
- [x] `pad_to_min_frames()` unit-tested against 6 scenarios: no padding needed, symmetric padding, both day-boundary clamps, whole-day fallback, zero-frame edge case
- [x] End-to-end: a 2-minute storm that previously produced nothing now correctly renders a padded clip
- [x] `tag_spans()` midnight fix verified against a real conditions-log fixture
- [x] `common.event_gap_minutes` / `event_min_frames` resolvers verified against all documented fallback/override combinations
- [x] Semgrep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)