### PR TITLE
Config page: split into App Settings / Cameras tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Config page: App Settings / Cameras tabs.** The Config page was one long
+  scroll through nine sections regardless of what you came to change. It's
+  now split into two tabs: **Cameras** (the camera list/picker, each
+  camera's full settings card, and network discovery) and **App Settings**
+  (everything global — Capture, Storage, Daily video, Yearly video, Weather &
+  astronomy tagging, Event video clips, Web UI, and Config page access).
+  Switching tabs never touches the network or discards an unsaved edit — both
+  tabs read and write the same in-memory config, and **Save config** in the
+  shared footer still saves everything regardless of which tab is showing.
+  The Cameras tab reuses the camera picker introduced for the navbar above,
+  selecting by list position rather than name (camera names are editable and
+  can transiently collide, e.g. right after "+ Add camera manually", which
+  starts every new camera out named the same thing).
 - **Navbar rework: a camera picker plus a Daily/Yearly/Events dropdown.**
   Replaces the old row of one pill button per camera (which stopped scaling
   past a handful of cameras) with a single `<select>`, shared by the navbar

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -514,6 +514,10 @@
   .swatch-radio input { accent-color: currentColor; }
   .swatch-dot { width: 14px; height: 14px; border-radius: 50%; display: inline-block; }
 
+  .cfg-tabs { margin-bottom: var(--space-4); }
+
+  .cfg-camera-picker-row { display: flex; gap: var(--space-2); align-items: center; margin-bottom: var(--space-3); }
+
   .cfg-camera-card {
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
@@ -620,7 +624,8 @@
 </main>
 <script>
 let state = { videos: [], cameras: [], camera: null, type: "daily",
-              lastVideoView: "daily", current: null };
+              lastVideoView: "daily", current: null,
+              configTab: "app", configCameraIndex: 0 };
 
 async function load() {
   const res = await fetch("/api/videos");
@@ -1530,22 +1535,42 @@ function tagCheckGroup(path, allTags) {
   return group;
 }
 
+// App Settings / Cameras split. The tab bar and #cfg-tab-body shell are built
+// once per Config page load; renderConfigTab() rebuilds just the body every
+// time the active tab changes (or the underlying data does), so it's the one
+// that gets called by tab clicks — never renderConfig(), which refetches
+// GET /api/config and would silently discard unsaved edits.
+const CONFIG_TABS = [["app", "App Settings"], ["cameras", "Cameras"]];
+
 function renderConfigForm(area) {
   const wrap = document.createElement("div");
   wrap.id = "cfg-view";
 
-  wrap.appendChild(buildCamerasSection());
-  wrap.appendChild(buildCaptureSection());
-  wrap.appendChild(buildStorageSection());
-  wrap.appendChild(buildDailyVideoSection());
-  wrap.appendChild(buildYearlySection());
-  wrap.appendChild(buildEventsSection());
-  wrap.appendChild(buildEventsVideoSection());
-  wrap.appendChild(buildWebappSection());
-  wrap.appendChild(buildSecuritySection());
+  const tabBar = document.createElement("div");
+  tabBar.className = "pills cfg-tabs";
+  CONFIG_TABS.forEach(([key, label]) => {
+    const btn = document.createElement("button");
+    btn.className = "pill" + (state.configTab === key ? " active" : "");
+    btn.dataset.tab = key;
+    btn.textContent = label;
+    btn.onclick = () => {
+      state.configTab = key;
+      tabBar.querySelectorAll(".pill").forEach(p => p.classList.remove("active"));
+      btn.classList.add("active");
+      renderConfigTab();
+    };
+    tabBar.appendChild(btn);
+  });
+  wrap.appendChild(tabBar);
+
+  const tabBody = document.createElement("div");
+  tabBody.id = "cfg-tab-body";
+  wrap.appendChild(tabBody);
 
   area.innerHTML = "";
   area.appendChild(wrap);
+
+  renderConfigTab();
 
   // The save/restart bar lives in #cfg-footer, a flex sibling of #player-area
   // (not inside the scrolling content) so it's always visible at the bottom
@@ -1617,6 +1642,33 @@ function renderConfigForm(area) {
   footer.appendChild(saveBtn);
   footer.appendChild(restartBtn);
   footer.appendChild(msg);
+}
+
+// Rebuilds #cfg-tab-body for the active tab. Always a full rebuild rather
+// than caching sections and toggling display — several sections (the
+// per-camera hint text in particular) are computed from *global* config
+// values at build time, so a card built before you edited, say, the global
+// capture interval would keep showing the stale number until this runs
+// again. Cheap: nine sections, no network. Safe: every field writes through
+// to state.configData on input/change via cfgSet, so the DOM is never the
+// source of truth and a rebuild can't lose an edit — only transient,
+// non-field state (an in-progress network scan, a typed-but-unsubmitted
+// passcode) resets, which is the correct tradeoff for both.
+function renderConfigTab() {
+  const body = document.getElementById("cfg-tab-body");
+  body.innerHTML = "";
+  if (state.configTab === "cameras") {
+    body.appendChild(buildCamerasTab());
+  } else {
+    body.appendChild(buildCaptureSection());
+    body.appendChild(buildStorageSection());
+    body.appendChild(buildDailyVideoSection());
+    body.appendChild(buildYearlySection());
+    body.appendChild(buildEventsSection());
+    body.appendChild(buildEventsVideoSection());
+    body.appendChild(buildWebappSection());
+    body.appendChild(buildSecuritySection());
+  }
 }
 
 function buildSecuritySection() {
@@ -1706,7 +1758,14 @@ function buildSecuritySection() {
   return sec;
 }
 
-function buildCamerasSection() {
+// The Cameras tab: intro hint, a picker + "+ Add" side by side, the selected
+// camera's card, then network discovery. Camera selection is by index, not
+// name — config field paths are index-based (cameras.${i}.name) and names
+// are user-editable and transiently non-unique (every "+ Add" starts a
+// camera out named "new-camera"; validate_config only catches duplicates at
+// save) — so state.configCameraIndex, not the camera's name, is the source
+// of truth for which card is showing.
+function buildCamerasTab() {
   const sec = document.createElement("div");
   sec.className = "cfg-section";
   sec.innerHTML = `<h3>Cameras</h3>
@@ -1718,13 +1777,24 @@ function buildCamerasSection() {
     if your devices use different accounts — each camera below picks which
     one it uses.</div>`;
 
-  const list = document.createElement("div");
-  sec.appendChild(list);
-  renderCameraCards(list);
+  const cams = state.configData.cameras || [];
+  if (state.configCameraIndex > cams.length - 1) {
+    state.configCameraIndex = Math.max(0, cams.length - 1);
+  }
+
+  const pickerRow = document.createElement("div");
+  pickerRow.className = "cfg-camera-picker-row";
+  pickerRow.appendChild(cameraPicker({
+    id: "config-camera-select",
+    ariaLabel: "Camera",
+    cameras: cams.map((cam, i) => ({value: String(i), label: cam.name || `Camera ${i + 1}`})),
+    selected: String(state.configCameraIndex),
+    emptyLabel: "No cameras configured",
+    onSelect: value => { state.configCameraIndex = parseInt(value, 10); renderConfigTab(); },
+  }));
 
   const addBtn = document.createElement("button");
   addBtn.className = "cfg-btn";
-  addBtn.style.marginTop = "8px";
   addBtn.textContent = "+ Add camera manually";
   addBtn.onclick = () => {
     if (!state.configData.cameras) state.configData.cameras = [];
@@ -1732,68 +1802,82 @@ function buildCamerasSection() {
       name: "new-camera", host: "", channel: 0, username: "admin",
       password: "${REOLINK_PASSWORD}", https: true, verify_ssl: false,
     });
-    renderCameraCards(list);
+    state.configCameraIndex = state.configData.cameras.length - 1;
+    renderConfigTab();
   };
-  sec.appendChild(addBtn);
-  sec.appendChild(buildDiscoverySection(list));
+  pickerRow.appendChild(addBtn);
+  sec.appendChild(pickerRow);
+
+  if (cams.length) {
+    sec.appendChild(renderCameraCard(state.configCameraIndex));
+  }
+
+  sec.appendChild(buildDiscoverySection());
   return sec;
 }
 
-function renderCameraCards(list) {
-  list.innerHTML = "";
+// One camera's editable card. Renaming a camera doesn't live-update the
+// picker label above until the next re-render — same as the card's own
+// header, which is equally static (title.textContent is set once here, not
+// wired to the Name input's oninput).
+function renderCameraCard(i) {
   const cams = state.configData.cameras || [];
-  cams.forEach((cam, i) => {
-    const card = document.createElement("div");
-    card.className = "cfg-camera-card";
+  const cam = cams[i];
 
-    const head = document.createElement("div");
-    head.className = "cfg-camera-head";
-    const title = document.createElement("strong");
-    title.textContent = cam.name || `Camera ${i + 1}`;
-    const rm = document.createElement("button");
-    rm.className = "cfg-btn cfg-btn-danger";
-    rm.textContent = "Remove";
-    rm.onclick = () => { cams.splice(i, 1); renderCameraCards(list); };
-    head.appendChild(title);
-    head.appendChild(rm);
-    card.appendChild(head);
+  const card = document.createElement("div");
+  card.className = "cfg-camera-card";
 
-    card.appendChild(fieldRow("Name", "Used in folder and file names for this camera's snapshots and "
-      + "videos (data/snapshots/<name>/...) — letters, digits, and dashes only, no spaces.",
-      textField(`cameras.${i}.name`)));
-    card.appendChild(fieldRow("Host", "The device ReoLapse talks to for this camera: either the camera's "
-      + "own IP (full resolution, no NVR dependency), or your NVR's IP if you'd rather pull every camera "
-      + "through one device and credential.", textField(`cameras.${i}.host`)));
-    card.appendChild(fieldRow("Channel", "0 when Host above is the camera itself. When Host is an NVR, "
-      + "this is that camera's channel number on it (check the NVR's own UI, or use Discover below).",
-      numberField(`cameras.${i}.channel`, {default: 0})));
-    card.appendChild(fieldRow("Username", "The login name for this camera/NVR account. A dedicated, "
-      + "least-privilege account is safer than reusing your admin login.", textField(`cameras.${i}.username`)));
-    card.appendChild(fieldRow("Password", "Which .env variable holds this camera's password. Add the real "
-      + "value there — never here. Different cameras can use different variables if they don't share an "
-      + "account.", passwordField(`cameras.${i}.password`), true));
-    card.appendChild(fieldRow("HTTPS", "Talk to this device over HTTPS instead of plain HTTP. Current "
-      + "Reolink firmware generally requires it.", checkboxField(`cameras.${i}.https`, {default: true})));
-    card.appendChild(fieldRow("Verify SSL cert", "Checks the device's TLS certificate against trusted "
-      + "authorities before trusting it. Leave this off — Reolink devices ship self-signed certificates, "
-      + "which would otherwise always fail this check.",
-      checkboxField(`cameras.${i}.verify_ssl`, {default: false})));
+  const head = document.createElement("div");
+  head.className = "cfg-camera-head";
+  const title = document.createElement("strong");
+  title.textContent = cam.name || `Camera ${i + 1}`;
+  const rm = document.createElement("button");
+  rm.className = "cfg-btn cfg-btn-danger";
+  rm.textContent = "Remove";
+  rm.onclick = () => {
+    cams.splice(i, 1);
+    state.configCameraIndex = Math.max(0, Math.min(state.configCameraIndex, cams.length - 1));
+    renderConfigTab();
+  };
+  head.appendChild(title);
+  head.appendChild(rm);
+  card.appendChild(head);
 
-    card.appendChild(buildCameraScheduleSection(i));
-    card.appendChild(buildCameraEventsSection(i));
+  card.appendChild(fieldRow("Name", "Used in folder and file names for this camera's snapshots and "
+    + "videos (data/snapshots/<name>/...) — letters, digits, and dashes only, no spaces.",
+    textField(`cameras.${i}.name`)));
+  card.appendChild(fieldRow("Host", "The device ReoLapse talks to for this camera: either the camera's "
+    + "own IP (full resolution, no NVR dependency), or your NVR's IP if you'd rather pull every camera "
+    + "through one device and credential.", textField(`cameras.${i}.host`)));
+  card.appendChild(fieldRow("Channel", "0 when Host above is the camera itself. When Host is an NVR, "
+    + "this is that camera's channel number on it (check the NVR's own UI, or use Discover below).",
+    numberField(`cameras.${i}.channel`, {default: 0})));
+  card.appendChild(fieldRow("Username", "The login name for this camera/NVR account. A dedicated, "
+    + "least-privilege account is safer than reusing your admin login.", textField(`cameras.${i}.username`)));
+  card.appendChild(fieldRow("Password", "Which .env variable holds this camera's password. Add the real "
+    + "value there — never here. Different cameras can use different variables if they don't share an "
+    + "account.", passwordField(`cameras.${i}.password`), true));
+  card.appendChild(fieldRow("HTTPS", "Talk to this device over HTTPS instead of plain HTTP. Current "
+    + "Reolink firmware generally requires it.", checkboxField(`cameras.${i}.https`, {default: true})));
+  card.appendChild(fieldRow("Verify SSL cert", "Checks the device's TLS certificate against trusted "
+    + "authorities before trusting it. Leave this off — Reolink devices ship self-signed certificates, "
+    + "which would otherwise always fail this check.",
+    checkboxField(`cameras.${i}.verify_ssl`, {default: false})));
 
-    if (cam.ptz_home) {
-      const hint = document.createElement("div");
-      hint.className = "cfg-hint";
-      hint.style.marginTop = "6px";
-      hint.textContent = "This camera has a PTZ home-position quarantine configured "
-        + "— not editable here yet; edit config.yaml directly to change it "
-        + "(it will be preserved as-is when you save from this page).";
-      card.appendChild(hint);
-    }
+  card.appendChild(buildCameraScheduleSection(i));
+  card.appendChild(buildCameraEventsSection(i));
 
-    list.appendChild(card);
-  });
+  if (cam.ptz_home) {
+    const hint = document.createElement("div");
+    hint.className = "cfg-hint";
+    hint.style.marginTop = "6px";
+    hint.textContent = "This camera has a PTZ home-position quarantine configured "
+      + "— not editable here yet; edit config.yaml directly to change it "
+      + "(it will be preserved as-is when you save from this page).";
+    card.appendChild(hint);
+  }
+
+  return card;
 }
 
 // Per-camera capture schedule. Each field falls back to the global setting, so
@@ -1906,7 +1990,7 @@ function buildCameraEventsSection(i) {
   return box;
 }
 
-function buildDiscoverySection(cameraList) {
+function buildDiscoverySection() {
   const box = document.createElement("div");
   box.style.marginTop = "16px";
   box.style.borderTop = "1px solid var(--border)";
@@ -1933,7 +2017,7 @@ function buildDiscoverySection(cameraList) {
       if (!data.found || !data.found.length) {
         results.innerHTML = `<div class="cfg-hint">No Reolink devices found on ${data.subnet}.0/24.</div>`;
       } else {
-        data.found.forEach(dev => results.appendChild(buildDiscoveredDeviceItem(dev, cameraList)));
+        data.found.forEach(dev => results.appendChild(buildDiscoveredDeviceItem(dev)));
       }
     } catch (e) {
       results.innerHTML = `<div class="cfg-hint">Scan failed: ${e}</div>`;
@@ -1947,7 +2031,7 @@ function buildDiscoverySection(cameraList) {
   return box;
 }
 
-function buildDiscoveredDeviceItem(dev, cameraList) {
+function buildDiscoveredDeviceItem(dev) {
   const item = document.createElement("div");
   item.className = "cfg-discover-item";
 
@@ -2020,14 +2104,8 @@ function buildDiscoveredDeviceItem(dev, cameraList) {
               password: "${" + varName + "}",
               https: dev.https, verify_ssl: false,
             });
-            renderCameraCards(cameraList);
-            const note = document.createElement("div");
-            note.className = "cfg-hint";
-            note.style.marginTop = "4px";
-            note.textContent = `Added. The password typed above was used only for this `
-              + `one-time lookup and isn't saved — set ${varName}=... in your .env file `
-              + `before restarting the capture service.`;
-            idResult.appendChild(note);
+            state.configCameraIndex = state.configData.cameras.length - 1;
+            renderConfigTab();
           };
           idResult.appendChild(addBtn);
         });


### PR DESCRIPTION
## Summary
The Config page was one long scroll through nine sections regardless of what you came to change. Splits into two tabs:

- **Cameras** — the camera picker (reusing the same `cameraPicker()` component from the navbar), each camera's full settings card, and network discovery.
- **App Settings** — everything global: Capture, Storage, Daily video, Yearly video, Weather & astronomy tagging, Event video clips, Web UI, and Config page access.

Switching tabs never touches the network or discards an unsaved edit — both tabs read/write the same in-memory config object, and **Save config** in the shared footer still saves everything regardless of which tab is active (the backend endpoint is all-or-nothing by design, so this needed no backend change). Cameras are selected by index rather than name, since names are user-editable and transiently non-unique while adding a camera.

No backend changes.

## Test plan
- [x] Playwright-verified: correct section count on each tab; editing a global setting on App Settings immediately reflects in a camera card's hint text on Cameras (proves live cross-tab reads); an in-progress edit survives a tab switch (proves write-through, not just re-render); camera selection by index survives add/remove; empty-camera-list state; zero network requests on tab switch
- [x] Semgrep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)