### PR TITLE
Header niceties: clickable logo/version, update banner, help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   small banner appears linking straight to its release notes — checked
   against GitHub's releases API, cached for 6 hours so it costs nothing on a
   normal page load, and silent (no banner, no error) if GitHub is unreachable
-  or the check fails. New `GET /api/update-check`.
+  or the check fails. New `GET /api/update-check`. A **?** button in the
+  top-right opens a small menu linking to the Wiki, GitHub Issues, and GitHub
+  Discussions.
 - **Storm/snow sensitivity sliders, and a real live-snow threshold.**
   Storm and snow detection thresholds could only be tuned as raw numbers
   buried in the Config page or `config.yaml` — there was no quick "make this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **A few small navigation niceties.** The logo/title in the top-left is now
+  clickable and takes you back to Daily videos. The version number next to it
+  links to that release's notes on GitHub. And when a newer release exists, a
+  small banner appears linking straight to its release notes — checked
+  against GitHub's releases API, cached for 6 hours so it costs nothing on a
+  normal page load, and silent (no banner, no error) if GitHub is unreachable
+  or the check fails. New `GET /api/update-check`.
 - **Storm/snow sensitivity sliders, and a real live-snow threshold.**
   Storm and snow detection thresholds could only be tuned as raw numbers
   buried in the Config page or `config.yaml` — there was no quick "make this

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -10,6 +10,7 @@ import functools
 import hashlib
 import hmac
 import json
+import logging
 import os
 import re
 import secrets
@@ -31,6 +32,8 @@ from common import (APP_VERSION, DEFAULT_CONFIG, load_config,  # noqa: E402
                     read_build_status, tzinfo_for, videos_dir)
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+log = logging.getLogger("reolapse.web")
 
 VIDEO_TYPES = ("daily", "yearly", "events")
 US_ZIP_RE = re.compile(r"^\d{5}$")
@@ -81,6 +84,84 @@ MIN_INTERVAL_SECONDS = 10
 
 # Keep in sync with forecast.py's MAX_FORECAST_DAYS — Open-Meteo's ceiling.
 MAX_FORECAST_DAYS = 10
+
+# --- Update check ------------------------------------------------------------
+# A quiet "a newer release exists" banner. Checked against GitHub's own
+# releases API, not npm/pip-style telemetry — no data about this install ever
+# leaves it. Cached in-process (same shape as forecast.py's _CACHE) so the
+# browser polling this on every page load doesn't turn into a GitHub API call
+# on every page load; a release lands at most every few weeks, so six hours of
+# staleness costs nothing. On any failure (offline, rate-limited, GitHub down)
+# this just silently reports no update — a missed banner for a few hours is
+# nothing, unlike the weather APIs where a wrong "all clear" hides a storm.
+GITHUB_RELEASES_LATEST_URL = "https://api.github.com/repos/SeriesOfTubez/reolapse/releases/latest"
+UPDATE_CHECK_CACHE_SECONDS = 6 * 3600
+
+_update_cache = {"checked_at": 0.0, "latest_version": None, "release_url": None}
+_update_cache_lock = threading.Lock()
+
+
+def _version_tuple(v):
+    """(major, minor, patch) for a plain 'X.Y.Z' string, or None if it isn't
+    one — a pre-release tag, a 'v' prefix left in by mistake, anything
+    unparseable. None compares as "don't know", never as an update."""
+    try:
+        parts = tuple(int(p) for p in str(v).split("."))
+        return parts if parts else None
+    except (TypeError, ValueError):
+        return None
+
+
+def check_for_update():
+    """{"current_version", "latest_version", "update_available", "release_url"}.
+
+    update_available is only True when the latest release is a STRICTLY newer
+    version than what's running — never merely "different" — so a dev build
+    running ahead of the last tag (e.g. this very checkout, mid-development)
+    doesn't light up the banner just because its VERSION file hasn't been
+    bumped yet.
+    """
+    now = time.time()
+    with _update_cache_lock:
+        stale = now - _update_cache["checked_at"] > UPDATE_CHECK_CACHE_SECONDS
+    if stale:
+        try:
+            resp = requests.get(GITHUB_RELEASES_LATEST_URL, timeout=5,
+                                headers={"Accept": "application/vnd.github+json"})
+            resp.raise_for_status()
+            data = resp.json()
+            tag = str(data.get("tag_name") or "").lstrip("v")
+            # Trust the tag/version text (rendered as text, never HTML) but
+            # not an arbitrary URL — only ever hand the frontend a link that
+            # actually points at this project's own GitHub releases page.
+            html_url = str(data.get("html_url") or "")
+            if not html_url.startswith("https://github.com/SeriesOfTubez/reolapse/releases/"):
+                html_url = None
+            with _update_cache_lock:
+                _update_cache["checked_at"] = now
+                _update_cache["latest_version"] = tag or None
+                _update_cache["release_url"] = html_url
+        except Exception:
+            log.warning("update check failed", exc_info=True)
+            with _update_cache_lock:
+                # Still mark it checked — a GitHub outage shouldn't turn into a
+                # request-per-page-load loop until it recovers.
+                _update_cache["checked_at"] = now
+
+    with _update_cache_lock:
+        latest = _update_cache["latest_version"]
+        release_url = _update_cache["release_url"]
+
+    current_t = _version_tuple(APP_VERSION)
+    latest_t = _version_tuple(latest)
+    update_available = bool(current_t and latest_t and latest_t > current_t)
+    return {
+        "current_version": APP_VERSION,
+        "latest_version": latest,
+        "update_available": update_available,
+        "release_url": release_url if update_available else None,
+    }
+
 
 # --- Config-page authentication --------------------------------------------
 # A single optional passcode (no username) gates the Config page and its
@@ -571,6 +652,12 @@ def create_app(cfg, config_path=None):
             # Only reached when there's nothing cached to fall back on either.
             return jsonify({"error": f"forecast unavailable: {exc}", "days": [],
                             "warnings": [], "sources": {}}), 503
+
+    @app.get("/api/update-check")
+    def update_check():
+        # Cached at module level (check_for_update), so this costs nothing on
+        # a normal page load — see the comment on GITHUB_RELEASES_LATEST_URL.
+        return jsonify(check_for_update())
 
     @app.get("/api/storage")
     def storage():

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -71,7 +71,8 @@
     flex-wrap: wrap;
   }
 
-  .brand { display: flex; align-items: center; gap: var(--space-2); }
+  .brand { display: flex; align-items: center; gap: var(--space-2); cursor: pointer; }
+  .brand:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
   .brand img { width: 26px; height: 26px; display: block; }
   .brand h1 {
     margin: 0;
@@ -79,7 +80,14 @@
     font-weight: var(--fw-semibold);
     letter-spacing: 0.2px;
   }
-  .brand .version { color: var(--text-3); font-size: var(--fs-xs); align-self: flex-end; margin-bottom: 3px; }
+  .brand .version {
+    color: var(--text-3); font-size: var(--fs-xs); align-self: flex-end;
+    margin-bottom: 3px; text-decoration: none;
+  }
+  /* The version link sits inside the clickable .brand "go home" region —
+     stop its own click from bubbling up and re-triggering that navigation
+     (see the version anchor's own click handler in the script). */
+  .brand .version:hover { text-decoration: underline; color: var(--accent); }
   .build-indicator { display: flex; align-items: center; gap: 6px; font-size: var(--fs-xs); color: var(--accent); white-space: nowrap; }
   .build-indicator[hidden] { display: none; }
   .build-spin { width: 10px; height: 10px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; display: inline-block; animation: build-spin 0.8s linear infinite; }
@@ -594,10 +602,10 @@
 </head>
 <body>
 <header>
-  <div class="brand">
+  <div class="brand" id="home-link" role="button" tabindex="0" title="Back to Daily videos">
     <img src="/static/logo.svg" alt="">
     <h1>ReoLapse</h1>
-    <span class="version" id="version"></span>
+    <a class="version" id="version" target="_blank" rel="noopener noreferrer"></a>
   </div>
   <div class="nav-group">
     <label class="nav-label" for="camera-select">Camera</label>
@@ -636,7 +644,10 @@ async function load() {
   state.videos = data.videos;
   if (data.version) {
     const v = document.getElementById("version");
-    if (v) v.textContent = "v" + data.version;
+    if (v) {
+      v.textContent = "v" + data.version;
+      v.href = `https://github.com/SeriesOfTubez/reolapse/releases/tag/v${data.version}`;
+    }
   }
 
   const warnBox = document.getElementById("warnings");
@@ -647,6 +658,7 @@ async function load() {
     div.textContent = w;
     warnBox.appendChild(div);
   });
+  checkForUpdate();
 
   // Keep the currently-selected camera across a refresh (e.g. the poll that
   // fires when a nightly build finishes) instead of always snapping back to
@@ -773,6 +785,41 @@ document.getElementById("types").addEventListener("click", e => {
   syncNav();
   refresh();
 });
+
+function goHome() {
+  state.type = "daily";
+  state.lastVideoView = "daily";
+  syncNav();
+  refresh();
+}
+const homeLink = document.getElementById("home-link");
+homeLink.addEventListener("click", goHome);
+homeLink.addEventListener("keydown", e => {
+  if (e.key === "Enter" || e.key === " ") { e.preventDefault(); goHome(); }
+});
+// The version link lives inside the clickable brand region — without this,
+// opening the release notes would also fire goHome() via bubbling.
+document.getElementById("version").addEventListener("click", e => e.stopPropagation());
+
+function checkForUpdate() {
+  fetch("/api/update-check").then(r => r.json()).then(u => {
+    const warnBox = document.getElementById("warnings");
+    const existing = warnBox.querySelector(".update-banner");
+    if (existing) existing.remove();
+    if (!u.update_available || !u.release_url) return;
+    const div = document.createElement("div");
+    div.className = "warning update-banner";
+    div.append(`A new version (v${u.latest_version}) is available — `);
+    const link = document.createElement("a");
+    link.href = u.release_url;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = "see what's new";
+    div.appendChild(link);
+    div.append(".");
+    warnBox.appendChild(div);
+  }).catch(() => {});   // best-effort; a failed check just means no banner
+}
 
 const VIDEO_VIEWS = ["daily", "yearly", "events"];
 const TOP_LEVEL_VIEWS = ["forecast", "storage", "config"];

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -90,6 +90,30 @@
   .brand .version:hover { text-decoration: underline; color: var(--accent); }
   .build-indicator { display: flex; align-items: center; gap: 6px; font-size: var(--fs-xs); color: var(--accent); white-space: nowrap; }
   .build-indicator[hidden] { display: none; }
+
+  /* margin-left: auto pins this to the far right of the header regardless of
+     how much else is in the flex row (camera count, pill count, etc.) */
+  .help-menu { position: relative; margin-left: auto; }
+  .help-btn {
+    width: 26px; height: 26px; border-radius: var(--radius-pill);
+    border: 1px solid var(--border); background: var(--surface-1);
+    color: var(--text-2); font: var(--fw-medium) var(--fs-sm)/1 var(--font-sans);
+    cursor: pointer; display: flex; align-items: center; justify-content: center;
+    padding: 0; transition: color var(--transition), border-color var(--transition);
+  }
+  .help-btn:hover, .help-btn[aria-expanded="true"] { color: var(--text-1); border-color: var(--border-strong); }
+  .help-dropdown {
+    position: absolute; top: calc(100% + var(--space-2)); right: 0;
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: var(--radius-md); padding: var(--space-1);
+    display: flex; flex-direction: column; min-width: 170px; z-index: 20;
+  }
+  .help-dropdown[hidden] { display: none; }
+  .help-dropdown a {
+    padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm);
+    color: var(--text-2); text-decoration: none; font-size: var(--fs-sm);
+  }
+  .help-dropdown a:hover { background: var(--surface-2); color: var(--text-1); }
   .build-spin { width: 10px; height: 10px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; display: inline-block; animation: build-spin 0.8s linear infinite; }
   @keyframes build-spin { to { transform: rotate(360deg); } }
 
@@ -622,6 +646,14 @@
     <button class="pill" data-type="config">Config</button>
   </div>
   <div class="build-indicator" id="build-indicator" hidden></div>
+  <div class="help-menu">
+    <button id="help-btn" class="help-btn" aria-haspopup="true" aria-expanded="false" title="Help &amp; feedback">?</button>
+    <div class="help-dropdown" id="help-dropdown" hidden>
+      <a href="https://github.com/SeriesOfTubez/reolapse/wiki" target="_blank" rel="noopener noreferrer">Wiki</a>
+      <a href="https://github.com/SeriesOfTubez/reolapse/issues" target="_blank" rel="noopener noreferrer">Report an issue</a>
+      <a href="https://github.com/SeriesOfTubez/reolapse/discussions" target="_blank" rel="noopener noreferrer">Discussions</a>
+    </div>
+  </div>
 </header>
 <div id="warnings"></div>
 <main>
@@ -800,6 +832,25 @@ homeLink.addEventListener("keydown", e => {
 // The version link lives inside the clickable brand region — without this,
 // opening the release notes would also fire goHome() via bubbling.
 document.getElementById("version").addEventListener("click", e => e.stopPropagation());
+
+const helpBtn = document.getElementById("help-btn");
+const helpDropdown = document.getElementById("help-dropdown");
+function closeHelpMenu() {
+  helpDropdown.hidden = true;
+  helpBtn.setAttribute("aria-expanded", "false");
+}
+helpBtn.addEventListener("click", e => {
+  e.stopPropagation();
+  if (!helpDropdown.hidden) { closeHelpMenu(); return; }
+  helpDropdown.hidden = false;
+  helpBtn.setAttribute("aria-expanded", "true");
+});
+document.addEventListener("click", e => {
+  if (!helpDropdown.hidden && !e.target.closest(".help-menu")) closeHelpMenu();
+});
+document.addEventListener("keydown", e => {
+  if (e.key === "Escape" && !helpDropdown.hidden) closeHelpMenu();
+});
 
 function checkForUpdate() {
   fetch("/api/update-check").then(r => r.json()).then(u => {


### PR DESCRIPTION
## Summary
- The logo/title in the header now goes back to Daily videos when clicked (mouse or keyboard) instead of being static decoration.
- The version number links to that release's notes on GitHub.
- A small banner appears when a newer release exists — checked against GitHub's releases API, cached in-process for 6 hours so a normal page load costs nothing, and silent on any failure rather than surfacing an error for a purely cosmetic feature. Only fires on a *strictly newer* release, so a dev build running ahead of the last tag doesn't light up the banner just because `VERSION` hasn't been bumped yet. New `GET /api/update-check`.
- A **?** button in the top-right opens a small menu linking to the Wiki, GitHub Issues, and GitHub Discussions (confirmed all three are actually enabled on the repo before wiring the links).

## Test plan
- [x] Backend: 5 scenarios verified against real code — newer available, same version, dev build ahead of latest (no false positive), network failure (degrades silently), and cache actually preventing repeated GitHub calls
- [x] Frontend, Playwright-verified against a live instance: version link text/href/target; forced "update available" banner renders with correct text and link; logo click (and Enter key) navigates home from any view; version link click doesn't bubble into the logo's navigation; help menu opens/closes on click, outside-click, and Escape; all three help links correct with `target="_blank" rel="noopener noreferrer"`; help menu genuinely pinned to the header's right edge
- [x] Release URL validated server-side against GitHub's own domain before ever reaching the browser
- [x] Semgrep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)