### PR TITLE
fix: keep tall videos inside the window so player controls stay visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Tall videos no longer push the player controls off-screen.** The player
+  already had a `max-height` meant to keep a video inside the window, but it
+  never took effect: it was a percentage of a container that was itself
+  content-sized, so the browser resolved it to "no limit". Any timelapse
+  taller than the viewport — easy to hit on a high-resolution monitor —
+  rendered at full size and shoved the speed/download/delete row below the
+  fold. The player now derives a real height from the area around it, so the
+  constraint actually applies: an oversized video shrinks to fit the window,
+  keeping its aspect ratio, with the controls always visible. Videos that
+  already fit are still shown at their native resolution and are never
+  upscaled.
+
 ## [0.4.0] - 2026-08-15
 
 ### Added

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -40,6 +40,10 @@
     --space-4: 16px;
     --space-5: 20px;
     --space-6: 24px;
+
+    /* Vertical room #controls needs under the video in the player. */
+    --player-chrome: 60px;
+
     /* Radii */
     --radius-sm: 6px;
     --radius-md: 8px;
@@ -242,18 +246,39 @@
     /* flex-start, not center: with overflow-y:auto, justify-content:center
        pushes overflowing content's start edge out of scroll range - tall
        views (Config, Storage) would have their top clipped and unreachable
-       by scrolling. Content shorter than the viewport (the video player) is
-       centered instead via margin:auto on .video-wrap below, which doesn't
-       have that bug. */
+       by scrolling. The video player centers itself instead, via
+       'justify-content: safe center' on .video-wrap below, which degrades
+       to flex-start on overflow and so doesn't have that bug. */
     justify-content: flex-start;
     padding: var(--space-5);
     overflow-y: auto;
   }
-  .video-wrap { margin: auto 0; display: flex; flex-direction: column; align-items: center; }
+  /* flex:1 + min-height:0 (rather than height:100%) gives .video-wrap a
+     definite height derived from #player-area. That is the whole point: a
+     percentage max-height on the video below only binds if its containing
+     block's height is definite. With the old content-sized .video-wrap the
+     percentage resolved to 'none', so a video taller than the window
+     overflowed and pushed #controls off-screen.
+
+     'safe center' centres the player but degrades to flex-start if the
+     contents ever do overflow (e.g. #controls wrapping on a narrow window),
+     avoiding the top-clipping described in the #player-area comment above. */
+  .video-wrap {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: safe center;
+  }
   #empty { margin: auto; }
   video {
+    /* No width/height: a replaced element sizes to its intrinsic dimensions,
+       so a 1080p clip renders at 1080p and is never upscaled. The two max-*
+       constraints shrink it proportionally when it doesn't fit; --player-chrome
+       reserves room for #controls underneath. */
     max-width: 100%;
-    max-height: calc(100% - 60px);
+    max-height: calc(100% - var(--player-chrome));
     border-radius: var(--radius-lg);
     background: #000;
   }


### PR DESCRIPTION
Reported in #27.

### The bug
The player already had a `max-height` meant to keep a video inside the window, but it never took effect. It was a percentage of `.video-wrap`, which is content-sized, so the percentage resolved to `none` and any video taller than the viewport pushed `#controls` below the fold.

### The fix
- `.video-wrap` gets a definite height derived from `#player-area` (`flex: 1` + `min-height: 0`), so the percentage actually resolves.
- Centres with `justify-content: safe center`, which degrades to `flex-start` on overflow rather than clipping the top edge out of scroll range — the failure mode already documented in the `#player-area` comment.
- The `60px` controls reserve becomes a `--player-chrome` custom property.
- Updates a neighbouring comment that credited the now-removed `margin: auto`.

### Why not the scale buttons proposed in #27
The patch there sets `width: 100%`, which replaces intrinsic sizing. A 1080p clip on a large monitor would be upscaled past native and look soft. Keeping the `max-*` constraints means the video is only ever shrunk to fit, never enlarged.

Not marked `Fixes #27` deliberately — that issue asks for scale buttons, which this declines, so it should be closed by hand with an explanation.

### Testing
Deployed to a live install and confirmed a 4K timelapse now fits a 1080p screen with controls visible, and smaller videos still render at native size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)