### PR TITLE
fix: make the Restart services button actually reload the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **The Restart services button now actually reloads the page.** It told you
+  the page would "disconnect for a few seconds, then reload" — and then never
+  reloaded, leaving you on a stale page with no sign the restart had finished.
+  The reload was only ever promised, never implemented. It now waits for the
+  web service to start answering again and reloads by itself. If the service
+  doesn't come back within 45 seconds it says so and points you at
+  `systemctl status reolapse-web`, instead of waiting forever.
+
 ## [0.4.0] - 2026-08-15
 
 ### Added

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -1660,6 +1660,42 @@ function tagCheckGroup(path, allTags) {
 // GET /api/config and would silently discard unsaved edits.
 const CONFIG_TABS = [["app", "App Settings"], ["cameras", "Cameras"]];
 
+// Restart-reconnect timings. The web service defers its own restart by ~1.5s
+// (schedule_self_restart) so the HTTP response can reach us first, and systemd
+// takes a moment more. Probing before that window closes would get an answer
+// from the old process that is about to die, and reload us into a page that is
+// immediately cut off - so wait it out before the first probe.
+const RESTART_GRACE_MS = 2500;
+const RESTART_POLL_MS = 1000;
+const RESTART_PROBE_TIMEOUT_MS = 2000;
+const RESTART_GIVE_UP_MS = 45000;
+
+function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+
+// Polls until the web service is serving again. /api/auth is the probe because
+// it is deliberately unauthenticated and cheap - any answer at all means Flask
+// is back. Returns false if it never comes back, so the caller can tell the
+// user rather than spinning forever.
+async function waitForServerBack() {
+  await sleep(RESTART_GRACE_MS);
+  const deadline = Date.now() + RESTART_GIVE_UP_MS;
+  while (Date.now() < deadline) {
+    const ctl = new AbortController();
+    const probeTimer = setTimeout(() => ctl.abort(), RESTART_PROBE_TIMEOUT_MS);
+    try {
+      // no-store so a cached 200 can't be mistaken for the service being up.
+      const res = await fetch("/api/auth", {cache: "no-store", signal: ctl.signal});
+      if (res.ok) return true;
+    } catch (e) {
+      // Connection refused/aborted while the service is down - keep waiting.
+    } finally {
+      clearTimeout(probeTimer);
+    }
+    await sleep(RESTART_POLL_MS);
+  }
+  return false;
+}
+
 function renderConfigForm(area) {
   const wrap = document.createElement("div");
   wrap.id = "cfg-view";
@@ -1737,22 +1773,36 @@ function renderConfigForm(area) {
     restartBtn.textContent = "Restarting…";
     msg.className = "cfg-msg";
     msg.textContent = "";
+    let note = "Services restarting…";
     try {
       const res = await fetch("/api/restart", {method: "POST"});
       const data = await res.json();
       if (data.error) {
+        // Nothing was restarted (the capture restart failed before the web
+        // service scheduled its own), so there is nothing to wait for.
         msg.className = "cfg-msg error";
         msg.textContent = data.error;
-      } else {
-        msg.className = "cfg-msg ok";
-        msg.textContent = data.note || "Restarting…";
+        restartBtn.disabled = false;
+        restartBtn.textContent = "Restart services";
+        return;
       }
+      note = data.note || note;
     } catch (e) {
       // The web service restarting itself can drop this very connection -
       // that's the expected outcome here, not a failure.
-      msg.className = "cfg-msg ok";
-      msg.textContent = "Services restarting — reload the page in a few seconds.";
     }
+    // A restart really is in flight now. The note above promises the page will
+    // come back by itself, so actually deliver that rather than leaving the
+    // user on a stale page: wait for the service to answer, then reload.
+    msg.className = "cfg-msg ok";
+    msg.textContent = note + " Reconnecting…";
+    if (await waitForServerBack()) {
+      location.reload();
+      return;
+    }
+    msg.className = "cfg-msg error";
+    msg.textContent = "The web service hasn't come back. Check it with "
+      + "`systemctl status reolapse-web` on the host, then refresh this page.";
     restartBtn.disabled = false;
     restartBtn.textContent = "Restart services";
   };


### PR DESCRIPTION
### The bug
The Restart services button told you the page would "disconnect for a few seconds, then reload" — and then never reloaded. Nothing anywhere called `location.reload()`; the reload was advertised but never implemented, leaving you on a stale page with no sign the restart had finished.

Which message you got was a race. The honest fallback ("reload the page in a few seconds") only appeared when the connection dropped before the response landed.

### The fix
Adds `waitForServerBack()`, which polls `/api/auth` — deliberately unauthenticated and cheap, so it doubles as a readiness probe — once a second until the service answers, then reloads.

- **Waits out a 2.5s grace period first.** `schedule_self_restart` defers the restart ~1.5s so the response can land, so an earlier probe would get a `200` from the process that is about to exit and reload into a page immediately cut off.
- **Each probe is capped** by an `AbortController` (2s), and `cache: "no-store"` prevents a cached `200` from faking a healthy service.
- **Gives up after 45s** with an actionable message pointing at `systemctl status reolapse-web`, rather than spinning forever.
- **Returns early when nothing restarted.** If the capture restart fails, the web service never schedules its own — that also covers Docker deployments, where `systemctl` isn't found.
- The button now stays disabled for the whole wait, re-enabling only on failure paths.

No backend change: the existing note is now true rather than aspirational.

### Testing
Deployed to a live systemd install and confirmed the page reloads by itself after clicking Restart services. JS syntax checked with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)